### PR TITLE
Make CI check Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -57,14 +59,22 @@ jobs:
     - name: Cargo doc
       run: cargo doc --features "${{matrix.features}}"
 
-  docsrs:
-    name: Check docs.rs
+  nightly:
+    name: docs.rs and Miri
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -Dwarnings
+      MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zrandomize-layout
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
       - uses: dtolnay/install@cargo-docs-rs
-      - run: cargo docs-rs
+      - name: Check docs.rs build
+        run: cargo docs-rs
+      - name: Setup Miri
+        run: cargo miri setup
+      - name: Run Miri
+        run: cargo miri test --features unsafe

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -671,6 +671,7 @@ mod tests {
         assert_eq!(dna, Nuc::lit(b"AGTC"));
     }
 
+    #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn revcomp_is_involution() {
         for dna in all_dna::<Nuc>().take(10000) {
@@ -682,6 +683,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn revcomp_matches_reverse_and_complement() {
         // Iterator revcomp isn't trivial, so compare against something that is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,8 @@
 //!
 //! # Features
 //!
-//! * **`unsafe`:** (highly experimental) This enables casting between [`&[Nuc]`](crate::Nuc)
-//!   and [`&[AmbiNuc]`](crate::AmbiNuc). This is not yet properly tested with Miri, so use at
-//!   your own risk.
+//! * **`unsafe`:** (experimental) This enables casting between [`&[Nuc]`](crate::Nuc)
+//!   and [`&[AmbiNuc]`](crate::AmbiNuc).
 
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]


### PR DESCRIPTION
Even though the `unsafe` code is pretty trivial, I haven't been running Miri against it, so I couldn't really claim any confidence in it. This PR fixes that!

While I'm touching CI, I decided to include a drive-by fix: Run CI against all `main` commits.
