### PR TITLE
Add `serde` support for `Seq<T>`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         rust_version: ${{fromJson(needs.setup.outputs.rust-versions)}}
-        features: [ "default", "unsafe" ]
+        features: [ "default", "serde", "unsafe", "all" ]
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
@@ -77,4 +77,4 @@ jobs:
       - name: Setup Miri
         run: cargo miri setup
       - name: Run Miri
-        run: cargo miri test --features unsafe
+        run: cargo miri test --features all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,94 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "nucs"
 version = "0.1.1"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,12 @@ edition = "2024"
 
 [features]
 default = []
+all = ["serde", "unsafe"]
 
 unsafe = []
 
 [dependencies]
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ assert_eq!(peptide.to_string(), "JABBY");
 
 * Packing
 * FASTA parsing
-* `serde` integration
 * Expansion of ambiguous k-mers into concrete k-mers
 * Base canonicalization
 * Unsafe casts for `Vec` and `Arc`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+* Add `serde` integration for `Seq<T>`.
+
 ## Version 0.1.1 (2025-07-10)
 
 * Fix documentation on docs.rs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 //!
 //! # Features
 //!
+//! * **`serde`:** Enables [`serde`](https://crates.io/crates/serde) integration for [`Seq<T>`].
 //! * **`unsafe`:** (experimental) This enables casting between [`&[Nuc]`](crate::Nuc)
 //!   and [`&[AmbiNuc]`](crate::AmbiNuc).
 


### PR DESCRIPTION
Also includes a drive-by fix to improve consistency of a header in `Seq<T>` docs.
