### PR TITLE
Release 0.1.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Releases
 
-## Unreleased
+## Version 0.1.2 (2025-07-12)
 
 * Add `serde` integration for `Seq<T>`.
 


### PR DESCRIPTION
Adds `serde` support for `Seq<T>`.