### PR TITLE
Add check to catch out-of-date `Cargo.lock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
       run: cargo test --release --features ${{matrix.features}}
     - name: Cargo doc
       run: cargo doc --features "${{matrix.features}}"
+    - name: Repo is clean # mainly prevents forgetting to commit Cargo.lock
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+            echo Dirty files:
+            git -c color.status=always status --short
+            exit 1
+        fi
 
   nightly:
     name: docs.rs and Miri


### PR DESCRIPTION
On cooperative projects, it's not uncommon for people to forget to commit `Cargo.lock` (or for merges to mess with it). This tries to detect that by requiring that the repo be clean after running all tests.