### PR TITLE
Rework rc translation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,8 @@
 * Allow `Seq` to be compared to strings. (#28)
 * Add `Symbol::seq` helper. (#29)
 * Add better support for `Seq` slices. (#32)
+* Replace `rev_*` translation methods with `rc_*` translation methods to avoid footgun.
+  Also renamed `FastTranslator` to `FullLookup` and pruned `NCBI1_RC`. (#38)
 
 ## Version 0.2.0 (2025-11-24)
 

--- a/benches/translation.rs
+++ b/benches/translation.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-use nucs::{AmbiNuc, DnaSlice, NCBI1, NCBI1_RC, Nuc};
+use nucs::{AmbiNuc, DnaSlice, NCBI1, Nuc};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::from_os_rng();
@@ -40,7 +40,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         g.bench_function(BenchmarkId::from_parameter(len), |b| {
             b.iter_batched_ref(
                 || (0..len).map(|_| rng.random()).collect::<Vec<Nuc>>(),
-                |dna| dna.rev_translated_to_vec_by(NCBI1_RC),
+                |dna| dna.rc_translated_to_vec_by(NCBI1),
                 BatchSize::SmallInput,
             )
         });
@@ -53,7 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         g.bench_function(BenchmarkId::from_parameter(len), |b| {
             b.iter_batched_ref(
                 || (0..len).map(|_| rng.random()).collect::<Vec<AmbiNuc>>(),
-                |dna| dna.rev_translated_to_vec_by(NCBI1_RC),
+                |dna| dna.rc_translated_to_vec_by(NCBI1),
                 BatchSize::SmallInput,
             )
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub use nuc::{AmbiNuc, Nuc, Nucleotide};
 pub use seq::Seq;
 pub use slice::DnaSlice;
 pub use symbol::Symbol;
-pub use translation::{NCBI1, NCBI1_RC};
+pub use translation::NCBI1;
 
 /// Common nucleotide sequence type
 pub type Dna = Seq<Vec<Nuc>>;

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -715,6 +715,12 @@ pub trait Nucleotide: Symbol {
     /// Instead of using this directly, prefer [`GeneticCode::translate`], as that tends to
     /// be clearer.
     fn translate<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino;
+
+    /// Translate reverse complement of a codon into an amino acid
+    ///
+    /// Instead of using this directly, prefer [`GeneticCode::translate_rc`], as that tends to
+    /// be clearer.
+    fn translate_rc<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino;
 }
 
 impl Nucleotide for Nuc {
@@ -729,6 +735,10 @@ impl Nucleotide for Nuc {
     fn translate<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino {
         genetic_code.translate_concrete_codon(codon)
     }
+
+    fn translate_rc<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino {
+        genetic_code.translate_rc_concrete_codon(codon)
+    }
 }
 
 impl Nucleotide for AmbiNuc {
@@ -742,6 +752,10 @@ impl Nucleotide for AmbiNuc {
 
     fn translate<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino {
         genetic_code.translate_ambiguous_codon(codon)
+    }
+
+    fn translate_rc<G: GeneticCode + ?Sized>(genetic_code: &G, codon: [Self; 3]) -> Self::Amino {
+        genetic_code.translate_rc_ambiguous_codon(codon)
     }
 }
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -222,6 +222,33 @@ impl<T: ?Sized> Seq<T> {
         Seq(self.0.as_ref().rev_translated_to_array_by(genetic_code))
     }
 
+    /// Translate reverse complement of nucleotides into fixed-length peptide.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of codons to be translated is different from the returned array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiNuc, NCBI1, Seq};
+    ///
+    /// let dna = AmbiNuc::seq(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let peptide: Seq<[_; 7]> = dna.rc_translated_to_array_by(NCBI1);
+    /// assert_eq!(peptide, "FAST*RC");
+    /// ```
+    pub fn rc_translated_to_array_by<S, G, const N: usize>(
+        &self,
+        genetic_code: G,
+    ) -> Seq<[<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino; N]>
+    where
+        T: AsRef<[S]>,
+        [S]: DnaSlice,
+        G: GeneticCode,
+    {
+        Seq(self.0.as_ref().rc_translated_to_array_by(genetic_code))
+    }
+
     /// Translate codons into [`Seq`]-wrapped peptide [`Vec`].
     ///
     /// For large sequences, this is usually much faster than populating directly from an iterator.
@@ -289,6 +316,29 @@ impl<T: ?Sized> Seq<T> {
         G: GeneticCode,
     {
         Seq(self.0.as_ref().rev_translated_to_vec_by(genetic_code))
+    }
+
+    /// Translate reverse complement of nucleotides into peptide [`Vec`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiNuc, NCBI1};
+    ///
+    /// let dna = AmbiNuc::seq(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let peptide = dna.rc_translated_to_vec_by(NCBI1);
+    /// assert_eq!(peptide, "FAST*RC");
+    /// ```
+    pub fn rc_translated_to_vec_by<S, G>(
+        &self,
+        genetic_code: G,
+    ) -> Seq<Vec<<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino>>
+    where
+        T: AsRef<[S]>,
+        [S]: DnaSlice,
+        G: GeneticCode,
+    {
+        Seq(self.0.as_ref().rc_translated_to_vec_by(genetic_code))
     }
 }
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -174,54 +174,6 @@ impl<T: ?Sized> Seq<T> {
         Seq(self.0.as_ref().translated_to_array_by(genetic_code))
     }
 
-    /// Translate codons into fixed-length [`Seq`]-wrapped  peptide in reverse order.
-    ///
-    /// This translates codons starting at the end. If the DNA can be converted to codons without
-    /// excess nucleotides, then this produces the exact reverse of the output of
-    /// [`translated_to_array_by`](Self::translated_to_array_by). It's intended to be used with
-    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
-    /// as that speeds up translation by folding the complementation into the translator.
-    ///
-    /// <div class="warning">
-    ///
-    /// **BEWARE:** This translates the *codons* in reverse order, *not* the nucleotides.
-    /// The `SDRAWKCAB`/`BACKWARDS` example below demonstrates this.
-    ///
-    /// </div>
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of codons to be translated is different from the returned array.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use nucs::{AmbiNuc, NCBI1, NCBI1_RC, Seq};
-    ///
-    /// let dna = AmbiNuc::seq(b"AGCGATAGGGCCTGGAAATGTGCCRAY");
-    /// let peptide: Seq<[_; 9]> = dna.translated_to_array_by(NCBI1);
-    /// assert_eq!(peptide, "SDRAWKCAB");
-    /// let peptide: Seq<[_; 9]> = dna.rev_translated_to_array_by(NCBI1);
-    /// assert_eq!(peptide, "BACKWARDS");
-    ///
-    /// // The proper way to use this for RC translation is with a reverse-complemented
-    /// // translation table like `NCBI1_RC`.
-    /// let dna = AmbiNuc::seq(b"NGCACCGCTAGGTACTGGCGAA");
-    /// let peptide: Seq<[_; 7]> = dna.rev_translated_to_array_by(NCBI1_RC);
-    /// assert_eq!(peptide, "FAST*RC");
-    /// ```
-    pub fn rev_translated_to_array_by<S, G, const N: usize>(
-        &self,
-        genetic_code: G,
-    ) -> Seq<[<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino; N]>
-    where
-        T: AsRef<[S]>,
-        [S]: DnaSlice,
-        G: GeneticCode,
-    {
-        Seq(self.0.as_ref().rev_translated_to_array_by(genetic_code))
-    }
-
     /// Translate reverse complement of nucleotides into fixed-length peptide.
     ///
     /// # Panics
@@ -272,50 +224,6 @@ impl<T: ?Sized> Seq<T> {
         G: GeneticCode,
     {
         Seq(self.0.as_ref().translated_to_vec_by(genetic_code))
-    }
-
-    /// Translate codons into [`Seq`]-wrapped peptide [`Vec`] in reverse order.
-    ///
-    /// This translates codons starting at the end. If the DNA can be converted to codons without
-    /// excess nucleotides, then this produces the exact reverse of the output of
-    /// [`translated_to_vec_by`](Self::translated_to_vec_by). It's intended to be used with
-    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
-    /// as that speeds up translation by folding the complementation into the translator.
-    ///
-    /// <div class="warning">
-    ///
-    /// **BEWARE:** This translates the *codons* in reverse order, *not* the nucleotides.
-    /// The `SDRAWKCAB`/`BACKWARDS` example below demonstrates this.
-    ///
-    /// </div>
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use nucs::{AmbiNuc, NCBI1, NCBI1_RC};
-    ///
-    /// let dna = AmbiNuc::seq(b"AGCGATAGGGCCTGGAAATGTGCCRAY");
-    /// let peptide = dna.translated_to_vec_by(NCBI1);
-    /// assert_eq!(peptide, "SDRAWKCAB");
-    /// let peptide = dna.rev_translated_to_vec_by(NCBI1);
-    /// assert_eq!(peptide, "BACKWARDS");
-    ///
-    /// // The proper way to use this for RC translation is with a reverse-complemented
-    /// // translation table like `NCBI1_RC`.
-    /// let dna = AmbiNuc::seq(b"NGCACCGCTAGGTACTGGCGAA");
-    /// let peptide = dna.rev_translated_to_vec_by(NCBI1_RC);
-    /// assert_eq!(peptide, "FAST*RC");
-    /// ```
-    pub fn rev_translated_to_vec_by<S, G>(
-        &self,
-        genetic_code: G,
-    ) -> Seq<Vec<<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino>>
-    where
-        T: AsRef<[S]>,
-        [S]: DnaSlice,
-        G: GeneticCode,
-    {
-        Seq(self.0.as_ref().rev_translated_to_vec_by(genetic_code))
     }
 
     /// Translate reverse complement of nucleotides into peptide [`Vec`].

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -179,7 +179,7 @@ impl<T: ?Sized> Seq<T> {
     /// This translates codons starting at the end. If the DNA can be converted to codons without
     /// excess nucleotides, then this produces the exact reverse of the output of
     /// [`translated_to_array_by`](Self::translated_to_array_by). It's intended to be used with
-    /// [`FastTranslator::reverse_complement`](crate::translation::FastTranslator::reverse_complement)
+    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
     /// as that speeds up translation by folding the complementation into the translator.
     ///
     /// <div class="warning">
@@ -252,7 +252,7 @@ impl<T: ?Sized> Seq<T> {
     /// This translates codons starting at the end. If the DNA can be converted to codons without
     /// excess nucleotides, then this produces the exact reverse of the output of
     /// [`translated_to_vec_by`](Self::translated_to_vec_by). It's intended to be used with
-    /// [`FastTranslator::reverse_complement`](crate::translation::FastTranslator::reverse_complement)
+    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
     /// as that speeds up translation by folding the complementation into the translator.
     ///
     /// <div class="warning">

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -284,6 +284,27 @@ pub trait DnaSlice {
         peptide
     }
 
+    /// Translate reverse complement of nucleotides into peptide [`Vec`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    ///
+    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let peptide = dna.rc_translated_to_vec_by(NCBI1);
+    /// assert_eq!(Seq(peptide), "FAST*RC");
+    /// ```
+    fn rc_translated_to_vec_by<G: GeneticCode>(
+        &self,
+        genetic_code: G,
+    ) -> Vec<<Self::Nuc as Nucleotide>::Amino> {
+        let codons = self.as_rcodons();
+        let mut peptide = vec![Default::default(); codons.len()];
+        codons.rc_translated_to_buf_by(genetic_code, &mut peptide);
+        peptide
+    }
+
     /// Translate codons into fixed-length peptide.
     ///
     /// # Panics
@@ -350,6 +371,30 @@ pub trait DnaSlice {
     ) -> [<Self::Nuc as Nucleotide>::Amino; N] {
         let mut buf = [Default::default(); _];
         self.rev_translated_to_buf_by(genetic_code, &mut buf);
+        buf
+    }
+
+    /// Translate reverse complement of nucleotides into fixed-length peptide.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of codons to be translated is different from the returned array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    ///
+    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let peptide: [_; 7] = dna.rc_translated_to_array_by(NCBI1);
+    /// assert_eq!(Seq(peptide), "FAST*RC");
+    /// ```
+    fn rc_translated_to_array_by<G: GeneticCode, const N: usize>(
+        &self,
+        genetic_code: G,
+    ) -> [<Self::Nuc as Nucleotide>::Amino; N] {
+        let mut buf = [Default::default(); _];
+        self.rc_translated_to_buf_by(genetic_code, &mut buf);
         buf
     }
 
@@ -447,6 +492,44 @@ pub trait DnaSlice {
         }
         for (amino, codon) in amino_remainder.iter_mut().rev().zip(codon_remainder) {
             *amino = genetic_code.translate(*codon);
+        }
+    }
+
+    /// Fill a buffer with amino acids built from translating reverse complement of nucleotides.
+    ///
+    /// For large sequences, this is usually much faster than populating directly from an iterator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of codons to be translated is different from the length of `buf`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    ///
+    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let mut peptide: [_; 7] = Default::default();
+    /// dna.rc_translated_to_buf_by(NCBI1, &mut peptide);
+    /// assert_eq!(Seq(peptide), "FAST*RC");
+    /// ```
+    fn rc_translated_to_buf_by<G: GeneticCode>(
+        &self,
+        genetic_code: G,
+        buf: &mut [<Self::Nuc as Nucleotide>::Amino],
+    ) {
+        const CHUNK_LEN: usize = 16;
+        let codons = self.as_rcodons();
+        assert_eq!(codons.len(), buf.len());
+        let (codon_chunks, codon_remainder) = codons.as_chunks::<CHUNK_LEN>();
+        let (amino_remainder, amino_chunks) = buf.as_rchunks_mut::<CHUNK_LEN>();
+        for (aminos, codons) in amino_chunks.iter_mut().rev().zip(codon_chunks) {
+            for (amino, codon) in aminos.iter_mut().rev().zip(codons) {
+                *amino = genetic_code.translate_rc(*codon);
+            }
+        }
+        for (amino, codon) in amino_remainder.iter_mut().rev().zip(codon_remainder) {
+            *amino = genetic_code.translate_rc(*codon);
         }
     }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -247,7 +247,7 @@ pub trait DnaSlice {
     /// This translates codons starting at the end. If the DNA can be converted to codons without
     /// excess nucleotides, then this produces the exact reverse of the output of
     /// [`translated_to_vec_by`](Self::translated_to_vec_by). It's intended to be used with
-    /// [`FastTranslator::reverse_complement`](crate::translation::FastTranslator::reverse_complement)
+    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
     /// as that speeds up translation by folding the complementation into the translator.
     ///
     /// <div class="warning">
@@ -313,7 +313,7 @@ pub trait DnaSlice {
     /// This translates codons starting at the end. If the DNA can be converted to codons without
     /// excess nucleotides, then this produces the exact reverse of the output of
     /// [`translated_to_array_by`](Self::translated_to_array_by). It's intended to be used with
-    /// [`FastTranslator::reverse_complement`](crate::translation::FastTranslator::reverse_complement)
+    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
     /// as that speeds up translation by folding the complementation into the translator.
     ///
     /// <div class="warning">
@@ -398,7 +398,7 @@ pub trait DnaSlice {
     /// This translates codons starting at the end. If the DNA can be converted to codons without
     /// excess nucleotides, then this produces the exact reverse of the output of
     /// [`translated_to_buf_by`](Self::translated_to_buf_by). It's intended to be used with
-    /// [`FastTranslator::reverse_complement`](crate::translation::FastTranslator::reverse_complement).
+    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement).
     ///
     /// <div class="warning">
     ///

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -242,48 +242,6 @@ pub trait DnaSlice {
         peptide
     }
 
-    /// Translate codons into peptide [`Vec`] in reverse order.
-    ///
-    /// This translates codons starting at the end. If the DNA can be converted to codons without
-    /// excess nucleotides, then this produces the exact reverse of the output of
-    /// [`translated_to_vec_by`](Self::translated_to_vec_by). It's intended to be used with
-    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
-    /// as that speeds up translation by folding the complementation into the translator.
-    ///
-    /// <div class="warning">
-    ///
-    /// **BEWARE:** This translates the *codons* in reverse order, *not* the nucleotides.
-    /// The `SDRAWKCAB`/`BACKWARDS` example below demonstrates this.
-    ///
-    /// </div>
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, NCBI1_RC, Seq};
-    ///
-    /// let dna = AmbiNuc::lit(b"AGCGATAGGGCCTGGAAATGTGCCRAY");
-    /// let peptide = dna.translated_to_vec_by(NCBI1);
-    /// assert_eq!(Seq(peptide), "SDRAWKCAB");
-    /// let peptide = dna.rev_translated_to_vec_by(NCBI1);
-    /// assert_eq!(Seq(peptide), "BACKWARDS");
-    ///
-    /// // The proper way to use this for RC translation is with a reverse-complemented
-    /// // translation table like `NCBI1_RC`.
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
-    /// let peptide = dna.rev_translated_to_vec_by(NCBI1_RC);
-    /// assert_eq!(Seq(peptide), "FAST*RC");
-    /// ```
-    fn rev_translated_to_vec_by<G: GeneticCode>(
-        &self,
-        genetic_code: G,
-    ) -> Vec<<Self::Nuc as Nucleotide>::Amino> {
-        let codons = self.as_rcodons();
-        let mut peptide = vec![Default::default(); codons.len()];
-        codons.rev_translated_to_buf_by(genetic_code, &mut peptide);
-        peptide
-    }
-
     /// Translate reverse complement of nucleotides into peptide [`Vec`].
     ///
     /// # Examples
@@ -326,51 +284,6 @@ pub trait DnaSlice {
     ) -> [<Self::Nuc as Nucleotide>::Amino; N] {
         let mut buf = [Default::default(); _];
         self.translated_to_buf_by(genetic_code, &mut buf);
-        buf
-    }
-
-    /// Translate codons into fixed-length peptide in reverse order.
-    ///
-    /// This translates codons starting at the end. If the DNA can be converted to codons without
-    /// excess nucleotides, then this produces the exact reverse of the output of
-    /// [`translated_to_array_by`](Self::translated_to_array_by). It's intended to be used with
-    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement)
-    /// as that speeds up translation by folding the complementation into the translator.
-    ///
-    /// <div class="warning">
-    ///
-    /// **BEWARE:** This translates the *codons* in reverse order, *not* the nucleotides.
-    /// The `SDRAWKCAB`/`BACKWARDS` example below demonstrates this.
-    ///
-    /// </div>
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of codons to be translated is different from the returned array.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, NCBI1_RC, Seq};
-    ///
-    /// let dna = AmbiNuc::lit(b"AGCGATAGGGCCTGGAAATGTGCCRAY");
-    /// let peptide: [_; 9] = dna.translated_to_array_by(NCBI1);
-    /// assert_eq!(Seq(peptide), "SDRAWKCAB");
-    /// let peptide: [_; 9] = dna.rev_translated_to_array_by(NCBI1);
-    /// assert_eq!(Seq(peptide), "BACKWARDS");
-    ///
-    /// // The proper way to use this for RC translation is with a reverse-complemented
-    /// // translation table like `NCBI1_RC`.
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
-    /// let peptide: [_; 7] = dna.rev_translated_to_array_by(NCBI1_RC);
-    /// assert_eq!(Seq(peptide), "FAST*RC");
-    /// ```
-    fn rev_translated_to_array_by<G: GeneticCode, const N: usize>(
-        &self,
-        genetic_code: G,
-    ) -> [<Self::Nuc as Nucleotide>::Amino; N] {
-        let mut buf = [Default::default(); _];
-        self.rev_translated_to_buf_by(genetic_code, &mut buf);
         buf
     }
 
@@ -432,65 +345,6 @@ pub trait DnaSlice {
             }
         }
         for (amino, codon) in std::iter::zip(amino_remainder, codon_remainder) {
-            *amino = genetic_code.translate(*codon);
-        }
-    }
-
-    /// Fill a buffer with amino acids built from translating codons in reverse.
-    ///
-    /// For large sequences, this is usually much faster than populating directly from an iterator.
-    ///
-    /// This translates codons starting at the end. If the DNA can be converted to codons without
-    /// excess nucleotides, then this produces the exact reverse of the output of
-    /// [`translated_to_buf_by`](Self::translated_to_buf_by). It's intended to be used with
-    /// [`FullLookup::reverse_complement`](crate::translation::FullLookup::reverse_complement).
-    ///
-    /// <div class="warning">
-    ///
-    /// **BEWARE:** This translates the *codons* in reverse order, *not* the nucleotides.
-    /// The `SDRAWKCAB`/`BACKWARDS` example below demonstrates this.
-    ///
-    /// </div>
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of codons to be translated is different from the length of `buf`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, NCBI1_RC, Seq};
-    ///
-    /// let mut dna = AmbiNuc::lit(b"AGCGATAGGGCCTGGAAATGTGCCRAY");
-    /// let mut peptide: [_; 9] = Default::default();
-    /// dna.translated_to_buf_by(NCBI1, &mut peptide);
-    /// assert_eq!(Seq(peptide), "SDRAWKCAB");
-    /// dna.rev_translated_to_buf_by(NCBI1, &mut peptide);
-    /// assert_eq!(Seq(peptide), "BACKWARDS");
-    ///
-    /// // The proper way to use this for RC translation is with a reverse-complemented
-    /// // translation table like `NCBI1_RC`.
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
-    /// let mut peptide: [_; 7] = Default::default();
-    /// dna.rev_translated_to_buf_by(NCBI1_RC, &mut peptide);
-    /// assert_eq!(Seq(peptide), "FAST*RC");
-    /// ```
-    fn rev_translated_to_buf_by<G: GeneticCode>(
-        &self,
-        genetic_code: G,
-        buf: &mut [<Self::Nuc as Nucleotide>::Amino],
-    ) {
-        const CHUNK_LEN: usize = 16;
-        let codons = self.as_rcodons();
-        assert_eq!(codons.len(), buf.len());
-        let (codon_chunks, codon_remainder) = codons.as_chunks::<CHUNK_LEN>();
-        let (amino_remainder, amino_chunks) = buf.as_rchunks_mut::<CHUNK_LEN>();
-        for (aminos, codons) in amino_chunks.iter_mut().rev().zip(codon_chunks) {
-            for (amino, codon) in aminos.iter_mut().rev().zip(codons) {
-                *amino = genetic_code.translate(*codon);
-            }
-        }
-        for (amino, codon) in amino_remainder.iter_mut().rev().zip(codon_remainder) {
             *amino = genetic_code.translate(*codon);
         }
     }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -106,16 +106,18 @@ impl GeneticCode for &[Amino; 64] {
 
 /// [`GeneticCode`] implementation optimized for speed over space.
 ///
-/// Each [`FastTranslator`] comes with about 18KiB of additional lookup tables,
+/// Each [`FullLookup`] comes with about 18KiB of additional lookup tables,
 /// dramatically improving translation speed, particularly for ambigous codons.
 #[derive(Clone)]
-pub struct FastTranslator {
+pub struct FullLookup {
     lookup: ConcreteLookup,
+    lookup_rc: ConcreteLookup,
     ambi_lookup: AmbiLookup,
+    ambi_lookup_rc: AmbiLookup,
 }
 
-impl FastTranslator {
-    /// Build [`FastTranslator`] from another [`GeneticCode`].
+impl FullLookup {
+    /// Build [`FullLookup`] from another [`GeneticCode`].
     ///
     /// This precalculates every possible ambiguous codon's translation.
     #[must_use]
@@ -126,7 +128,7 @@ impl FastTranslator {
         }))
     }
 
-    /// Build [`FastTranslator`] from a table of [`Amino`]s.
+    /// Build [`FullLookup`] from a table of [`Amino`]s.
     ///
     /// The [`Amino`]s must correspond to all codons in ascending lexicographical order.
     ///
@@ -135,10 +137,14 @@ impl FastTranslator {
     #[must_use]
     pub const fn from_table(table: &[Amino; 64]) -> Self {
         let lookup = ConcreteLookup::from_table(table);
+        let lookup_rc = lookup.reverse_complement();
         let ambi_lookup = lookup.to_ambi_lookup();
+        let ambi_lookup_rc = ambi_lookup.reverse_complement();
         Self {
             lookup,
+            lookup_rc,
             ambi_lookup,
+            ambi_lookup_rc,
         }
     }
 
@@ -177,7 +183,7 @@ impl FastTranslator {
     ///
     /// ```
     /// use nucs::{Amino, Nuc, NCBI1};
-    /// use nucs::translation::{FastTranslator, GeneticCode};
+    /// use nucs::translation::GeneticCode;
     /// use Nuc::{A, C, G, T};
     ///
     /// assert_eq!(NCBI1.translate([A, T, G]), Amino::M);
@@ -201,13 +207,15 @@ impl FastTranslator {
     #[must_use]
     pub const fn reverse_complement(&self) -> Self {
         Self {
-            lookup: self.lookup.reverse_complement(),
-            ambi_lookup: self.ambi_lookup.reverse_complement(),
+            lookup: ConcreteLookup(self.lookup_rc.0),
+            lookup_rc: ConcreteLookup(self.lookup.0),
+            ambi_lookup: AmbiLookup(self.ambi_lookup_rc.0),
+            ambi_lookup_rc: AmbiLookup(self.ambi_lookup.0),
         }
     }
 }
 
-impl GeneticCode for &FastTranslator {
+impl GeneticCode for &FullLookup {
     #[inline(always)]
     fn translate_concrete_codon(&self, codon: [Nuc; 3]) -> Amino {
         (&self.lookup).translate_concrete_codon(codon)
@@ -217,9 +225,19 @@ impl GeneticCode for &FastTranslator {
     fn translate_ambiguous_codon(&self, codon: [AmbiNuc; 3]) -> AmbiAmino {
         (&self.ambi_lookup).translate_ambiguous_codon(codon)
     }
+
+    #[inline(always)]
+    fn translate_rc_concrete_codon(&self, codon: [Nuc; 3]) -> Amino {
+        (&self.lookup_rc).translate_concrete_codon(codon)
+    }
+
+    #[inline(always)]
+    fn translate_rc_ambiguous_codon(&self, codon: [AmbiNuc; 3]) -> AmbiAmino {
+        (&self.ambi_lookup_rc).translate_ambiguous_codon(codon)
+    }
 }
 
-impl std::fmt::Debug for FastTranslator {
+impl std::fmt::Debug for FullLookup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.lookup.fmt(f)
     }
@@ -491,80 +509,80 @@ fn fmt_genetic_code(
 /// Standard code
 ///
 /// The reverse complemented version is [`NCBI1_RC`].
-pub const NCBI1: &FastTranslator = &ncbi(0);
+pub const NCBI1: &FullLookup = &ncbi(0);
 /// Standard code (reverse complemented)
 ///
 /// This is the reverse complemented version of [`NCBI1`]. If other genetic codes are needed,
 /// they can be defined like so:
 /// ```
-/// use nucs::translation::{FastTranslator, NCBI2};
+/// use nucs::translation::{FullLookup, NCBI2};
 ///
-/// const NCBI2_RC: &FastTranslator = &NCBI2.reverse_complement();
+/// const NCBI2_RC: &FullLookup = &NCBI2.reverse_complement();
 /// ```
-pub const NCBI1_RC: &FastTranslator = &NCBI1.reverse_complement();
+pub const NCBI1_RC: &FullLookup = &NCBI1.reverse_complement();
 /// Vertebrate mitochondrial code
-pub const NCBI2: &FastTranslator = &ncbi(1);
+pub const NCBI2: &FullLookup = &ncbi(1);
 /// Yeast mitochondrial code
-pub const NCBI3: &FastTranslator = &ncbi(2);
+pub const NCBI3: &FullLookup = &ncbi(2);
 /// Mold, protozoan, and coelenterate mitochondrial code as well as mycoplasma and spiroplasma code
-pub const NCBI4: &FastTranslator = &ncbi(3);
+pub const NCBI4: &FullLookup = &ncbi(3);
 /// Invertebrate mitochondrial code
-pub const NCBI5: &FastTranslator = &ncbi(4);
+pub const NCBI5: &FullLookup = &ncbi(4);
 /// Ciliate dasycladacean and hexamita nuclear code
-pub const NCBI6: &FastTranslator = &ncbi(5);
+pub const NCBI6: &FullLookup = &ncbi(5);
 /// Echinoderm and flatworm mitochondrial code
-pub const NCBI9: &FastTranslator = &ncbi(6);
+pub const NCBI9: &FullLookup = &ncbi(6);
 /// Euplotid nuclear code
-pub const NCBI10: &FastTranslator = &ncbi(7);
+pub const NCBI10: &FullLookup = &ncbi(7);
 /// Bacterial, archaeal and plant plastid code
-pub const NCBI11: &FastTranslator = &ncbi(8);
+pub const NCBI11: &FullLookup = &ncbi(8);
 /// Alternative yeast nuclear code
-pub const NCBI12: &FastTranslator = &ncbi(9);
+pub const NCBI12: &FullLookup = &ncbi(9);
 /// Ascidian mitochondrial code
-pub const NCBI13: &FastTranslator = &ncbi(10);
+pub const NCBI13: &FullLookup = &ncbi(10);
 /// Alternative flatworm mitochondrial code
-pub const NCBI14: &FastTranslator = &ncbi(11);
+pub const NCBI14: &FullLookup = &ncbi(11);
 /// Blepharisma nuclear code
-pub const NCBI15: &FastTranslator = &ncbi(12);
+pub const NCBI15: &FullLookup = &ncbi(12);
 /// Chlorophycean mitochondrial code
-pub const NCBI16: &FastTranslator = &ncbi(13);
+pub const NCBI16: &FullLookup = &ncbi(13);
 /// Trematode mitochondrial code
-pub const NCBI21: &FastTranslator = &ncbi(14);
+pub const NCBI21: &FullLookup = &ncbi(14);
 /// Scenedesmus obliquus mitochondrial code
-pub const NCBI22: &FastTranslator = &ncbi(15);
+pub const NCBI22: &FullLookup = &ncbi(15);
 /// Thraustochytrium mitochondrial code
-pub const NCBI23: &FastTranslator = &ncbi(16);
+pub const NCBI23: &FullLookup = &ncbi(16);
 /// Pterobranchia mitochondrial code
-pub const NCBI24: &FastTranslator = &ncbi(17);
+pub const NCBI24: &FullLookup = &ncbi(17);
 /// Candidate division SR1 and gracilibacteria code
-pub const NCBI25: &FastTranslator = &ncbi(18);
+pub const NCBI25: &FullLookup = &ncbi(18);
 /// Pachysolen tannophilus nuclear code
-pub const NCBI26: &FastTranslator = &ncbi(19);
+pub const NCBI26: &FullLookup = &ncbi(19);
 /// Karyorelict nuclear code
-pub const NCBI27: &FastTranslator = &ncbi(20);
+pub const NCBI27: &FullLookup = &ncbi(20);
 /// Condylostoma nuclear code
-pub const NCBI28: &FastTranslator = &ncbi(21);
+pub const NCBI28: &FullLookup = &ncbi(21);
 /// Mesodinium nuclear code
-pub const NCBI29: &FastTranslator = &ncbi(22);
+pub const NCBI29: &FullLookup = &ncbi(22);
 /// Peritrich nuclear code
-pub const NCBI30: &FastTranslator = &ncbi(23);
+pub const NCBI30: &FullLookup = &ncbi(23);
 /// Blastocrithidia nuclear code
-pub const NCBI31: &FastTranslator = &ncbi(24);
+pub const NCBI31: &FullLookup = &ncbi(24);
 /// Balanophoraceae plastid code
-pub const NCBI32: &FastTranslator = &ncbi(25);
+pub const NCBI32: &FullLookup = &ncbi(25);
 /// Cephalodiscidae mitochondrial code
-pub const NCBI33: &FastTranslator = &ncbi(26);
+pub const NCBI33: &FullLookup = &ncbi(26);
 /// Enterosoma code
-pub const NCBI34: &FastTranslator = &ncbi(27);
+pub const NCBI34: &FullLookup = &ncbi(27);
 /// Peptacetobacter code
-pub const NCBI35: &FastTranslator = &ncbi(28);
+pub const NCBI35: &FullLookup = &ncbi(28);
 /// Anaerococcus and onthovivens code
-pub const NCBI36: &FastTranslator = &ncbi(29);
+pub const NCBI36: &FullLookup = &ncbi(29);
 /// Absconditabacterales genetic code
-pub const NCBI37: &FastTranslator = &ncbi(30);
+pub const NCBI37: &FullLookup = &ncbi(30);
 
-const fn ncbi(i: usize) -> FastTranslator {
-    FastTranslator::from_table(&NCBI_DATA[i])
+const fn ncbi(i: usize) -> FullLookup {
+    FullLookup::from_table(&NCBI_DATA[i])
 }
 
 macro_rules! aminos {
@@ -670,13 +688,13 @@ mod tests {
     #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn compare_fast_lookup_against_reference_implementation() {
-        // In order to be able to build `FastLookup`s for all NCBI tables at compile-time
+        // In order to be able to build `FullLookup`s for all NCBI tables at compile-time
         // in 1 second, the ambiguous lookup generation code is convoluted. (doing things the
         // obvious way would result in `nucs` taking 30 seconds to compile) To improve confidence,
-        // we check that for all codons and NCBI tables, `FastLookup` gives the same results as
+        // we check that for all codons and NCBI tables, `FullLookup` gives the same results as
         // the simpler implementations provided by `&[Amino; 64]` and `GeneticCode`.
         for raw in &NCBI_DATA {
-            let fast = &FastTranslator::from_table(raw);
+            let fast = &FullLookup::from_table(raw);
             assert_genetic_codes_eq(&fast, &raw);
         }
     }
@@ -684,7 +702,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn fast_lookup_can_be_built_from_other_genetic_code() {
-        let new = &FastTranslator::from_genetic_code(&NCBI1);
+        let new = &FullLookup::from_genetic_code(&NCBI1);
         assert_genetic_codes_eq(&new, &NCBI1);
     }
 
@@ -692,7 +710,7 @@ mod tests {
     #[test]
     fn fast_lookup_conversion_roundtrips() {
         let table = &NCBI_DATA[0];
-        assert_eq!(&FastTranslator::from_table(table).to_table(), table);
+        assert_eq!(&FullLookup::from_table(table).to_table(), table);
     }
 
     #[test]

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -110,14 +110,8 @@ impl GeneticCode for &[Amino; 64] {
 /// dramatically improving translation speed, particularly for ambigous codons.
 #[derive(Clone)]
 pub struct FastTranslator {
-    // `lookup` is for `Nuc`s and `ambi_lookup` is for `AmbiNuc`s. They have similar layouts;
-    // each `Nuc`/`AmbiNuc` can be thought of as a hexidecimal digit, and each codon is thought of
-    // as a big-endian 3-digit hexadecimal index into the lookup table. A `Nuc` caps out at 0x8,
-    // but an `AmbiNuc` caps out at 0xf, hence the difference in table lengths. Note that this
-    // layout still requires entries for indices containing the digit 0, so we need an extra
-    // entry at the start for 0x000.
-    lookup: [Amino; 1 + 0x888],          // about 2KiB in size
-    ambi_lookup: [AmbiAmino; 1 + 0xfff], // 16KiB in size because `AmbiAmino` is 4 bytes.
+    lookup: ConcreteLookup,
+    ambi_lookup: AmbiLookup,
 }
 
 impl FastTranslator {
@@ -140,81 +134,12 @@ impl FastTranslator {
     /// but can be done at compile-time.
     #[must_use]
     pub const fn from_table(table: &[Amino; 64]) -> Self {
-        let lookup = Self::build_concrete_lookup(table);
+        let lookup = ConcreteLookup::from_table(table);
+        let ambi_lookup = lookup.to_ambi_lookup();
         Self {
-            ambi_lookup: Self::build_ambi_lookup(&lookup),
             lookup,
+            ambi_lookup,
         }
-    }
-
-    const fn build_concrete_lookup(table: &[Amino; 64]) -> [Amino; 1 + 0x888] {
-        let mut lookup = [Amino::A; _];
-        let mut i = 0;
-        while i < table.len() {
-            lookup[Self::table_index_to_fast_lookup_index(i)] = table[i];
-            i += 1;
-        }
-        lookup
-    }
-
-    const fn build_ambi_lookup(concrete_lookup: &[Amino; 1 + 0x888]) -> [AmbiAmino; 1 + 0xfff] {
-        // This is 20x faster than calculating each lookup entry in isolation because it dedupes
-        // the work of building merged table results. It treats the lookup like a lattice of sets:
-        // Instead of having to build each set from scratch, it just builds them out of two
-        // smaller sets. And counting upwards has the nice property of visiting the sets in
-        // topological order so subsets will be populated before the sets that they feed into.
-        // When an index contains multiple bits (when _b variables are non-zero), that means it's
-        // ambiguous and should composed out of the results of smaller indices. In theory this
-        // could be flattened into a single unnested loop that populates the indices in order,
-        // but then the iterations couldn't share as much work, so it'd take about 50% longer.
-        let mut lookup = [AmbiAmino::X; _];
-        let mut n1 = 0x100;
-        while n1 <= 0xf00 {
-            let (n1_a, n1_b) = Self::split_lowest_bit(n1);
-            if n1_b == 0 {
-                let mut n2 = 0x010;
-                while n2 <= 0x0f0 {
-                    let n1_n2 = n1 | n2;
-                    let (n2_a, n2_b) = Self::split_lowest_bit(n2);
-                    if n2_b == 0 {
-                        let mut n3 = 0x001;
-                        while n3 <= 0x00f {
-                            let n1_n2_n3 = n1_n2 | n3;
-                            let (n3_a, n3_b) = Self::split_lowest_bit(n3);
-                            if n3_b == 0 {
-                                lookup[n1_n2_n3] = AmbiAmino::from_amino(concrete_lookup[n1_n2_n3]);
-                            } else {
-                                lookup[n1_n2_n3] = lookup[n1_n2 | n3_a].or(lookup[n1_n2 | n3_b]);
-                            }
-                            n3 += 0x001;
-                        }
-                    } else {
-                        let n1_n2_a = n1 | n2_a;
-                        let n1_n2_b = n1 | n2_b;
-                        let mut n3 = 0x001;
-                        while n3 <= 0x00f {
-                            lookup[n1_n2 | n3] = lookup[n1_n2_a | n3].or(lookup[n1_n2_b | n3]);
-                            n3 += 1;
-                        }
-                    }
-                    n2 += 0x010;
-                }
-            } else {
-                let mut n2_n3 = 0x011;
-                while n2_n3 <= 0x0ff {
-                    lookup[n1 | n2_n3] = lookup[n1_a | n2_n3].or(lookup[n1_b | n2_n3]);
-                    n2_n3 += 1;
-                }
-            }
-            n1 += 0x100;
-        }
-        lookup
-    }
-
-    // Split a number into its lowest bit and other bits.
-    const fn split_lowest_bit(i: usize) -> (usize, usize) {
-        let lowest = 1 << i.trailing_zeros();
-        (lowest, i & !lowest)
     }
 
     /// Convert to simple amino acid table.
@@ -242,13 +167,7 @@ impl FastTranslator {
     /// ```
     #[must_use]
     pub const fn to_table(&self) -> [Amino; 64] {
-        let mut table = [Amino::A; _];
-        let mut i = 0;
-        while i < table.len() {
-            table[i] = self.lookup[Self::table_index_to_fast_lookup_index(i)];
-            i += 1;
-        }
-        table
+        self.lookup.to_table()
     }
 
     /// Return the reverse complement of this translation table.
@@ -281,28 +200,81 @@ impl FastTranslator {
     /// ```
     #[must_use]
     pub const fn reverse_complement(&self) -> Self {
+        Self {
+            lookup: self.lookup.reverse_complement(),
+            ambi_lookup: self.ambi_lookup.reverse_complement(),
+        }
+    }
+}
+
+impl GeneticCode for &FastTranslator {
+    #[inline(always)]
+    fn translate_concrete_codon(&self, codon: [Nuc; 3]) -> Amino {
+        (&self.lookup).translate_concrete_codon(codon)
+    }
+
+    #[inline(always)]
+    fn translate_ambiguous_codon(&self, codon: [AmbiNuc; 3]) -> AmbiAmino {
+        (&self.ambi_lookup).translate_ambiguous_codon(codon)
+    }
+}
+
+impl std::fmt::Debug for FastTranslator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.lookup.fmt(f)
+    }
+}
+
+/// A lookup to efficiently translate concrete codons
+///
+/// The lookup doesn't allocate, but is about 2KiB in size. It supports very fast translation of
+/// concrete codons (`[Nuc; 3]`) but is slower at translating ambiguous codons, or
+/// reverse-complement codons.
+#[derive(Clone)]
+pub struct ConcreteLookup([Amino; 1 + 0x888]);
+// The table layout:
+// Each `Nuc` can be thought of as a hexidecimal digit, and each codon as a big-endian
+// 3-digit hexadecimal index into the lookup table. A `Nuc` caps out at 0x8, so TTT
+// corresponds to 0x888, plus an extra spot is needed at the start for 0x000.
+
+impl ConcreteLookup {
+    /// Build [`ConcreteLookup`] from a table of [`Amino`]s.
+    ///
+    /// The [`Amino`]s must correspond to all codons in ascending lexicographical order.
+    #[must_use]
+    pub const fn from_table(table: &[Amino; 64]) -> Self {
         let mut lookup = [Amino::A; _];
         let mut i = 0;
-        let max = lookup.len();
-        while i < max {
-            let complement_idx = Self::reverse_complement_index(i);
-            // The gaps in this lookup can be complemented to invalid indices.
-            if complement_idx < max {
-                lookup[i] = self.lookup[complement_idx];
-            }
+        while i < table.len() {
+            lookup[Self::table_index_to_fast_lookup_index(i)] = table[i];
             i += 1;
         }
-        let mut ambi_lookup = [AmbiAmino::X; _];
+        Self(lookup)
+    }
+
+    /// Convert to simple amino acid table.
+    ///
+    /// The returned [`Amino`]s correspond to all codons in ascending lexicographical order.
+    /// Although such a table can be used as a [`GeneticCode`], it's intended more for interop
+    /// or inspection.
+    ///
+    /// ```
+    /// use nucs::{Amino, NCBI1};
+    /// use nucs::translation::ConcreteLookup;
+    ///
+    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let lookup = ConcreteLookup::from_table(&table);
+    /// assert_eq!(lookup.to_table(), table);
+    /// ```
+    #[must_use]
+    pub const fn to_table(&self) -> [Amino; 64] {
+        let mut table = [Amino::A; _];
         let mut i = 0;
-        let max = ambi_lookup.len();
-        while i < max {
-            ambi_lookup[i] = self.ambi_lookup[Self::reverse_complement_index(i)];
+        while i < table.len() {
+            table[i] = self.0[Self::table_index_to_fast_lookup_index(i)];
             i += 1;
         }
-        Self {
-            lookup,
-            ambi_lookup,
-        }
+        table
     }
 
     // (by "table", I mean list of one amino per concrete codon, in lexicographical order)
@@ -313,42 +285,207 @@ impl FastTranslator {
         (n1 << 8) | (n2 << 4) | n3
     }
 
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "valid lookup indexes are 12 bits"
-    )]
-    const fn reverse_complement_index(idx: usize) -> usize {
-        ((idx as u16).reverse_bits() >> 4) as usize
+    /// Return the reverse complement of this translation table.
+    ///
+    /// It produces a copy of the translation table where the reverse complement of each codon
+    /// maps to the same amino acid as before. For example:
+    ///
+    /// ```
+    /// use nucs::{Amino, Nuc};
+    /// use nucs::translation::{ConcreteLookup, GeneticCode};
+    /// use Nuc::{A, C, G, T};
+    ///
+    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let lookup = ConcreteLookup::from_table(&table);
+    /// assert_eq!((&lookup).translate([A, T, G]), Amino::Q);
+    /// let lookup_rc = lookup.reverse_complement();
+    /// // ATG reverse-complemented is CAT, so...
+    /// assert_eq!((&lookup_rc).translate([C, A, T]), Amino::Q);
+    /// ```
+    #[must_use]
+    pub const fn reverse_complement(&self) -> Self {
+        let mut lookup = [Amino::A; _];
+        let mut i = 0;
+        let max = lookup.len();
+        while i < max {
+            let complement_idx = reverse_complement_index(i);
+            // The gaps in this lookup can be complemented to invalid indices.
+            if complement_idx < max {
+                lookup[i] = self.0[complement_idx];
+            }
+            i += 1;
+        }
+        Self(lookup)
+    }
+
+    /// Build [`AmbiLookup`] from this [`ConcreteLookup`].
+    ///
+    /// This precalculates every possible ambiguous codon's translation,
+    /// but can be done at compile-time.
+    #[must_use]
+    pub const fn to_ambi_lookup(&self) -> AmbiLookup {
+        // This is 20x faster than calculating each lookup entry in isolation because it dedupes
+        // the work of building merged table results. It treats the lookup like a lattice of sets:
+        // Instead of having to build each set from scratch, it just builds them out of two
+        // smaller sets. And counting upwards has the nice property of visiting the sets in
+        // topological order so subsets will be populated before the sets that they feed into.
+        // When an index contains multiple bits (when _b variables are non-zero), that means it's
+        // ambiguous and should composed out of the results of smaller indices. In theory this
+        // could be flattened into a single unnested loop that populates the indices in order,
+        // but then the iterations couldn't share as much work, so it'd take about 50% longer.
+        let mut lookup = [AmbiAmino::X; _];
+        let mut n1 = 0x100;
+        while n1 <= 0xf00 {
+            let (n1_a, n1_b) = Self::split_lowest_bit(n1);
+            if n1_b == 0 {
+                let mut n2 = 0x010;
+                while n2 <= 0x0f0 {
+                    let n1_n2 = n1 | n2;
+                    let (n2_a, n2_b) = Self::split_lowest_bit(n2);
+                    if n2_b == 0 {
+                        let mut n3 = 0x001;
+                        while n3 <= 0x00f {
+                            let n1_n2_n3 = n1_n2 | n3;
+                            let (n3_a, n3_b) = Self::split_lowest_bit(n3);
+                            if n3_b == 0 {
+                                lookup[n1_n2_n3] = AmbiAmino::from_amino(self.0[n1_n2_n3]);
+                            } else {
+                                lookup[n1_n2_n3] = lookup[n1_n2 | n3_a].or(lookup[n1_n2 | n3_b]);
+                            }
+                            n3 += 0x001;
+                        }
+                    } else {
+                        let n1_n2_a = n1 | n2_a;
+                        let n1_n2_b = n1 | n2_b;
+                        let mut n3 = 0x001;
+                        while n3 <= 0x00f {
+                            lookup[n1_n2 | n3] = lookup[n1_n2_a | n3].or(lookup[n1_n2_b | n3]);
+                            n3 += 1;
+                        }
+                    }
+                    n2 += 0x010;
+                }
+            } else {
+                let mut n2_n3 = 0x011;
+                while n2_n3 <= 0x0ff {
+                    lookup[n1 | n2_n3] = lookup[n1_a | n2_n3].or(lookup[n1_b | n2_n3]);
+                    n2_n3 += 1;
+                }
+            }
+            n1 += 0x100;
+        }
+        AmbiLookup(lookup)
+    }
+
+    // Split a number into its lowest bit and other bits.
+    const fn split_lowest_bit(i: usize) -> (usize, usize) {
+        let lowest = 1 << i.trailing_zeros();
+        (lowest, i & !lowest)
     }
 }
 
-impl GeneticCode for &FastTranslator {
+impl GeneticCode for &ConcreteLookup {
     #[inline(always)]
     fn translate_concrete_codon(&self, codon: [Nuc; 3]) -> Amino {
         let [n1, n2, n3] = codon;
-        self.lookup[((n1 as usize) << 8) | ((n2 as usize) << 4) | (n3 as usize)]
+        self.0[((n1 as usize) << 8) | ((n2 as usize) << 4) | (n3 as usize)]
+    }
+}
+
+impl std::fmt::Debug for ConcreteLookup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_genetic_code(&self, f)
+    }
+}
+
+/// A lookup to efficiently translate ambiguous codons
+///
+/// The lookup doesn't allocate, but is about 2KiB in size. It supports very fast translation of
+/// ambiguous codons (`[AmbiNuc; 3]`) but is slower at translating concrete codons, or
+/// reverse-complement codons.
+#[derive(Clone)]
+pub struct AmbiLookup([AmbiAmino; 1 + 0xfff]);
+// The table layout is similar to `ConcreteLookup`:
+// Each `AmbiNuc` can be thought of as a hexidecimal digit, and each codon as a big-endian
+// 3-digit hexadecimal index into the lookup table. An `AmbiNuc` caps out at 0xf, so NNN
+// corresponds to 0xfff, plus an extra spot is needed at the start for 0x000.
+
+impl AmbiLookup {
+    /// Return the reverse complement of this translation table.
+    ///
+    /// It produces a copy of the translation table where the reverse complement of each codon
+    /// maps to the same amino acid as before. For example:
+    ///
+    /// ```
+    /// use nucs::{Amino, Nuc, NCBI1};
+    /// use nucs::translation::{ConcreteLookup, GeneticCode};
+    /// use Nuc::{A, C, G, T};
+    ///
+    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let lookup = ConcreteLookup::from_table(&table).to_ambi_lookup();
+    /// assert_eq!((&lookup).translate([A, T, G]), Amino::Q);
+    /// let lookup_rc = lookup.reverse_complement();
+    /// // ATG reverse-complemented is CAT, so...
+    /// assert_eq!((&lookup_rc).translate([C, A, T]), Amino::Q);
+    /// ```
+    #[must_use]
+    pub const fn reverse_complement(&self) -> Self {
+        let mut ambi_lookup = [AmbiAmino::X; _];
+        let mut i = 0;
+        let max = ambi_lookup.len();
+        while i < max {
+            ambi_lookup[i] = self.0[reverse_complement_index(i)];
+            i += 1;
+        }
+        Self(ambi_lookup)
+    }
+}
+
+impl GeneticCode for &AmbiLookup {
+    #[inline(always)]
+    fn translate_concrete_codon(&self, codon: [Nuc; 3]) -> Amino {
+        let [n1, n2, n3] = codon;
+        let amino = self.translate_ambiguous_codon([n1.into(), n2.into(), n3.into()]);
+        amino
+            .try_into()
+            .expect("BUG: to_ambi_lookup mapped concrete codon to ambi amino")
     }
 
     #[inline(always)]
     fn translate_ambiguous_codon(&self, codon: [AmbiNuc; 3]) -> AmbiAmino {
         let [n1, n2, n3] = codon;
-        self.ambi_lookup[((n1 as usize) << 8) | ((n2 as usize) << 4) | (n3 as usize)]
+        self.0[((n1 as usize) << 8) | ((n2 as usize) << 4) | (n3 as usize)]
     }
 }
 
-impl std::fmt::Debug for FastTranslator {
+impl std::fmt::Debug for AmbiLookup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut map = f.debug_map();
-        for n1 in Nuc::ALL {
-            for n2 in Nuc::ALL {
-                for n3 in Nuc::ALL {
-                    let codon = [n1, n2, n3];
-                    map.entry(&codon.display(), &self.translate([n1, n2, n3]));
-                }
+        fmt_genetic_code(&self, f)
+    }
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "valid lookup indexes are 12 bits"
+)]
+const fn reverse_complement_index(idx: usize) -> usize {
+    ((idx as u16).reverse_bits() >> 4) as usize
+}
+
+fn fmt_genetic_code(
+    genetic_code: &impl GeneticCode,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    let mut map = f.debug_map();
+    for n1 in Nuc::ALL {
+        for n2 in Nuc::ALL {
+            for n3 in Nuc::ALL {
+                let codon = [n1, n2, n3];
+                map.entry(&codon.display(), &genetic_code.translate([n1, n2, n3]));
             }
         }
-        map.finish()
     }
+    map.finish()
 }
 
 /// Standard code

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -191,19 +191,6 @@ impl FullLookup {
     /// // ATG reverse-complemented is CAT, so...
     /// assert_eq!(ncbi1_rc.translate([C, A, T]), Amino::M);
     /// ```
-    ///
-    /// This is useful in combination with methods like [`DnaSlice::rev_translated_to_vec_by`],
-    /// because it allows complementation to folded into translation, reducing the amount of work
-    /// needed to produce reverse-complement translations. Actual usage would look something like:
-    ///
-    /// ```
-    /// use nucs::{Amino, DnaSlice, Nuc, NCBI1_RC, Seq};
-    /// // NCBI1_RC is &NCBI1.reverse_complement()
-    ///
-    /// let dna = Nuc::lit(b"GCACCGCTAGGTACTGGCGAA");
-    /// let peptide = dna.rev_translated_to_vec_by(NCBI1_RC);
-    /// assert_eq!(peptide, Amino::lit(b"FAST*RC"));
-    /// ```
     #[must_use]
     pub const fn reverse_complement(&self) -> Self {
         Self {
@@ -715,9 +702,8 @@ mod tests {
 
     #[test]
     fn fast_lookup_reverse_complement() {
-        let ncbi1_rc = const { &NCBI1.reverse_complement() };
         let dna = Nuc::lit(b"ATCTTCGGGGGGAATTAAAAACTAATAAAGTTCAACAATGGTTGGCATCTCTTCCCGGGG");
-        let peptide = dna.rev_translated_to_vec_by(ncbi1_rc);
+        let peptide = dna.rc_translated_to_vec_by(NCBI1);
         assert_eq!(peptide, Amino::lit(b"PREEMPTIVELY*FLIPPED"));
     }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -175,31 +175,6 @@ impl FullLookup {
     pub const fn to_table(&self) -> [Amino; 64] {
         self.lookup.to_table()
     }
-
-    /// Return the reverse complement of this translation table.
-    ///
-    /// It produces a copy of the translation table where the reverse complement of each codon
-    /// maps to the same amino acid as before. For example:
-    ///
-    /// ```
-    /// use nucs::{Amino, Nuc, NCBI1};
-    /// use nucs::translation::GeneticCode;
-    /// use Nuc::{A, C, G, T};
-    ///
-    /// assert_eq!(NCBI1.translate([A, T, G]), Amino::M);
-    /// let ncbi1_rc = &NCBI1.reverse_complement();
-    /// // ATG reverse-complemented is CAT, so...
-    /// assert_eq!(ncbi1_rc.translate([C, A, T]), Amino::M);
-    /// ```
-    #[must_use]
-    pub const fn reverse_complement(&self) -> Self {
-        Self {
-            lookup: ConcreteLookup(self.lookup_rc.0),
-            lookup_rc: ConcreteLookup(self.lookup.0),
-            ambi_lookup: AmbiLookup(self.ambi_lookup_rc.0),
-            ambi_lookup_rc: AmbiLookup(self.ambi_lookup.0),
-        }
-    }
 }
 
 impl GeneticCode for &FullLookup {
@@ -494,19 +469,7 @@ fn fmt_genetic_code(
 }
 
 /// Standard code
-///
-/// The reverse complemented version is [`NCBI1_RC`].
 pub const NCBI1: &FullLookup = &ncbi(0);
-/// Standard code (reverse complemented)
-///
-/// This is the reverse complemented version of [`NCBI1`]. If other genetic codes are needed,
-/// they can be defined like so:
-/// ```
-/// use nucs::translation::{FullLookup, NCBI2};
-///
-/// const NCBI2_RC: &FullLookup = &NCBI2.reverse_complement();
-/// ```
-pub const NCBI1_RC: &FullLookup = &NCBI1.reverse_complement();
 /// Vertebrate mitochondrial code
 pub const NCBI2: &FullLookup = &ncbi(1);
 /// Yeast mitochondrial code

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -22,6 +22,26 @@ pub trait GeneticCode {
         N::translate(self, codon)
     }
 
+    /// Translate reverse complement of a codon to an amino acid
+    ///
+    /// Examples
+    ///
+    /// ```
+    /// use nucs::{AmbiAmino, Amino, AmbiNuc, Nuc, translation::GeneticCode};
+    /// use Nuc::{A, G, T};
+    ///
+    /// let genetic_code = |codon: [Nuc; 3]| match codon {
+    ///    [A, T, G] => Amino::W,
+    ///    _ => Amino::Stop,
+    /// };
+    /// assert_eq!(genetic_code.translate_rc(Nuc::lit(b"CAT")), Amino::W);
+    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::lit(b"CAT")), AmbiAmino::W);
+    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::lit(b"ANT")), AmbiAmino::Stop);
+    /// ```
+    fn translate_rc<N: Nucleotide>(&self, codon: [N; 3]) -> N::Amino {
+        N::translate_rc(self, codon)
+    }
+
     /// Translate a concrete codon to an amino acid
     ///
     /// Consider calling [`GeneticCode::translate`] instead; this primarily exists to be provided
@@ -41,6 +61,26 @@ pub trait GeneticCode {
             .map(|codon| AmbiAmino::from(self.translate_concrete_codon(codon)))
             .reduce(|a, b| a | b)
             .expect("BUG: null nucleotide encountered")
+    }
+
+    /// Translate reverse complement of a concrete codon to an amino acid
+    ///
+    /// Consider calling [`GeneticCode::translate_rc`] instead; this primarily exists to be provided
+    /// by implementors of [`GeneticCode`].
+    fn translate_rc_concrete_codon(&self, mut codon: [Nuc; 3]) -> Amino {
+        codon.reverse();
+        codon.complement();
+        self.translate_concrete_codon(codon)
+    }
+
+    /// Translate reverse complement of an ambiguous codon to an amino acid
+    ///
+    /// Consider calling [`GeneticCode::translate_rc`] instead; this primarily exists to be provided
+    /// by implementors of [`GeneticCode`].
+    fn translate_rc_ambiguous_codon(&self, mut codon: [AmbiNuc; 3]) -> AmbiAmino {
+        codon.reverse();
+        codon.complement();
+        self.translate_ambiguous_codon(codon)
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -285,15 +285,21 @@ impl ConcreteLookup {
     #[must_use]
     pub const fn reverse_complement(&self) -> Self {
         let mut lookup = [Amino::A; _];
-        let mut i = 0;
-        let max = lookup.len();
-        while i < max {
-            let complement_idx = reverse_complement_index(i);
-            // The gaps in this lookup can be complemented to invalid indices.
-            if complement_idx < max {
-                lookup[i] = self.0[complement_idx];
+        // As before, this could be flattened into a single unnested loop, but this nested
+        // loop results in much sparser work.
+        let mut n1 = 0x100;
+        while n1 <= 0x800 {
+            let mut n2 = 0x010;
+            while n2 <= 0x080 {
+                let mut n3 = 0x001;
+                while n3 <= 0x008 {
+                    let n1_n2_n3 = n1 | n2 | n3;
+                    lookup[n1_n2_n3] = self.0[reverse_complement_index(n1_n2_n3)];
+                    n3 <<= 1;
+                }
+                n2 <<= 1;
             }
-            i += 1;
+            n1 <<= 1;
         }
         Self(lookup)
     }
@@ -411,11 +417,21 @@ impl AmbiLookup {
     #[must_use]
     pub const fn reverse_complement(&self) -> Self {
         let mut ambi_lookup = [AmbiAmino::X; _];
-        let mut i = 0;
-        let max = ambi_lookup.len();
-        while i < max {
-            ambi_lookup[i] = self.0[reverse_complement_index(i)];
-            i += 1;
+        // As before, this could be flattened into a single unnested loop, but this nested
+        // loop results in much sparser work.
+        let mut n1 = 0x100;
+        while n1 <= 0xf00 {
+            let mut n2 = 0x010;
+            while n2 <= 0x0f0 {
+                let mut n3 = 0x001;
+                while n3 <= 0x00f {
+                    let n1_n2_n3 = n1 | n2 | n3;
+                    ambi_lookup[n1_n2_n3] = self.0[reverse_complement_index(n1_n2_n3)];
+                    n3 <<= 1;
+                }
+                n2 <<= 1;
+            }
+            n1 <<= 1;
         }
         Self(ambi_lookup)
     }


### PR DESCRIPTION
The current API has the footgun that there's nothing to stop you from using e.g. `dna.rev_translated_to_vec_by(NCBI1)` even though that's almost certainly not what you want. This PR fixes that by changing  the `FastTranslator` type into a `FullLookup` type that holds both forward and RC lookup tables, adding `GeneticCode::translate_rc` and changing the `rev_translated_*` methods to `rc_translated_*` methods that automatically use the RC lookup tables. This also includes speedups to calculating the RC lookup tables so that all NCBI tables have their RC versions precomputed.