### PR TITLE
Exhaustively test fast RC translation

### DIFF
--- a/src/translation.rs
+++ b/src/translation.rs
@@ -427,11 +427,11 @@ impl AmbiLookup {
                 while n3 <= 0x00f {
                     let n1_n2_n3 = n1 | n2 | n3;
                     ambi_lookup[n1_n2_n3] = self.0[reverse_complement_index(n1_n2_n3)];
-                    n3 <<= 1;
+                    n3 += 0x001;
                 }
-                n2 <<= 1;
+                n2 += 0x010;
             }
-            n1 <<= 1;
+            n1 += 0x100;
         }
         Self(ambi_lookup)
     }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -686,6 +686,42 @@ mod tests {
         assert_eq!(peptide, Amino::lit(b"PREEMPTIVELY*FLIPPED"));
     }
 
+    #[test]
+    fn exhaustively_test_reverse_complement_concrete_lookups() {
+        for n1 in Nuc::ALL {
+            for n2 in Nuc::ALL {
+                for n3 in Nuc::ALL {
+                    let codon = [n1, n2, n3];
+                    let mut codon_rc = codon;
+                    codon_rc.revcomp();
+                    assert_eq!(
+                        NCBI1.translate_rc(codon),
+                        NCBI1.translate(codon_rc),
+                        "Mismatch for {codon:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn exhaustively_test_reverse_complement_ambiguous_lookups() {
+        for n1 in AmbiNuc::ALL {
+            for n2 in AmbiNuc::ALL {
+                for n3 in AmbiNuc::ALL {
+                    let codon = [n1, n2, n3];
+                    let mut codon_rc = codon;
+                    codon_rc.revcomp();
+                    assert_eq!(
+                        NCBI1.translate_rc(codon),
+                        NCBI1.translate(codon_rc),
+                        "Mismatch for {codon:?}"
+                    );
+                }
+            }
+        }
+    }
+
     fn assert_genetic_codes_eq(g1: &impl GeneticCode, g2: &impl GeneticCode) {
         for n1 in Nuc::ALL {
             for n2 in Nuc::ALL {


### PR DESCRIPTION
This adds exhaustive tests for RC translation lookup tables, catching a bug in the change to make RC lookup generation faster.
