### PR TITLE
Rename `lit` to `arr`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ codons[3..8].revcomp();
 //       ACAC    ACA TAT CTT ACG CTT AGG AAA TCT GAC CCG    AA
 // Changing it to:           AGA TTT CCT AAG CGT
 
-dna.extend(const { Nuc::lit(b"CCAACCATTGATGAG") });
+dna.extend(const { Nuc::arr(b"CCAACCATTGATGAG") });
 
 let peptide = dna.translated_to_vec_by(NCBI1);
 assert_eq!(peptide, "THIS*IS*A*PEPTIDE");

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
   * `Seq` can now wrap slices, not just owned data. (#32)
   * `Seq` can be compared to strings for easier testing. (#28)
   * `Seq` now has translation methods. (#30)
+* Rename `T::lit` to `T::arr` to improve clarity. (#42)
 
 ## Version 0.2.0 (2025-11-24)
 

--- a/src/amino.rs
+++ b/src/amino.rs
@@ -68,7 +68,7 @@ pub enum Amino {
 
 impl Amino {
     /// All [`Amino`]s sorted in ascending order
-    pub const ALL: [Self; 23] = Self::lit(b"*ACDEFGHIKLMNOPQRSTUVWY");
+    pub const ALL: [Self; 23] = Self::arr(b"*ACDEFGHIKLMNOPQRSTUVWY");
 
     /// Return uppercase string representation
     ///
@@ -180,7 +180,7 @@ impl Amino {
     /// ```
     /// use nucs::Amino;
     ///
-    /// let aas1 = Amino::lit(b"ACME*WIDGETS");
+    /// let aas1 = Amino::arr(b"ACME*WIDGETS");
     /// // ...is shorthand for...
     /// use Amino::{A, C, M, E, Stop, W, I, D, G, T, S};
     /// let aas2 = [A, C, M, E, Stop, W, I, D, G, E, T, S];
@@ -194,7 +194,7 @@ impl Amino {
     /// because the returned array must have the same length.
     #[must_use]
     #[track_caller]
-    pub const fn lit<const N: usize>(literal: &[u8; N]) -> [Amino; N] {
+    pub const fn arr<const N: usize>(literal: &[u8; N]) -> [Amino; N] {
         let mut aas = [Self::A; N];
         let mut i = 0;
         while i < literal.len() {
@@ -229,7 +229,7 @@ impl Amino {
     #[must_use]
     #[track_caller]
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Amino; N]> {
-        Seq(Self::lit(literal))
+        Seq(Self::arr(literal))
     }
 }
 
@@ -514,7 +514,7 @@ impl AmbiAmino {
     /// ```
     /// use nucs::AmbiAmino;
     ///
-    /// let aas1 = AmbiAmino::lit(b"TOO*LONG");
+    /// let aas1 = AmbiAmino::arr(b"TOO*LONG");
     /// // ...is shorthand for...
     /// let aas2 = [
     ///     AmbiAmino::T, AmbiAmino::O, AmbiAmino::O, AmbiAmino::STOP,
@@ -530,7 +530,7 @@ impl AmbiAmino {
     /// because the returned array must have the same length.
     #[must_use]
     #[track_caller]
-    pub const fn lit<const N: usize>(literal: &[u8; N]) -> [AmbiAmino; N] {
+    pub const fn arr<const N: usize>(literal: &[u8; N]) -> [AmbiAmino; N] {
         let mut aas = [Self::A; N];
         let mut i = 0;
         while i < literal.len() {
@@ -567,7 +567,7 @@ impl AmbiAmino {
     #[must_use]
     #[track_caller]
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[AmbiAmino; N]> {
-        Seq(Self::lit(literal))
+        Seq(Self::arr(literal))
     }
 
     /// Return iterator of [`Amino`]s that this ambiguous amino acid could be.
@@ -581,7 +581,7 @@ impl AmbiAmino {
     /// use nucs::{AmbiAmino, Amino};
     ///
     /// let aa = AmbiAmino::A | AmbiAmino::B | AmbiAmino::C;
-    /// assert!(aa.iter().eq(Amino::lit(b"ACDN")));
+    /// assert!(aa.iter().eq(Amino::arr(b"ACDN")));
     /// ```
     pub fn iter(self) -> AmbiAminoIter {
         AmbiAminoIter::new(self)
@@ -885,8 +885,8 @@ impl Symbol for Amino {
         Self::to_ascii(self)
     }
 
-    fn lit<const N: usize>(literal: &[u8; N]) -> [Self; N] {
-        Self::lit(literal)
+    fn arr<const N: usize>(literal: &[u8; N]) -> [Self; N] {
+        Self::arr(literal)
     }
 
     fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Self; N]> {
@@ -910,8 +910,8 @@ impl Symbol for AmbiAmino {
         Self::to_ascii(self)
     }
 
-    fn lit<const N: usize>(literal: &[u8; N]) -> [Self; N] {
-        Self::lit(literal)
+    fn arr<const N: usize>(literal: &[u8; N]) -> [Self; N] {
+        Self::arr(literal)
     }
 
     fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Self; N]> {

--- a/src/casts.rs
+++ b/src/casts.rs
@@ -38,8 +38,8 @@ fn is_representable_as_nucs(nucs: &[AmbiNuc]) -> bool {
 /// ```
 /// use nucs::{AmbiNuc, Nuc};
 ///
-/// let dna = Nuc::lit(b"CATATTAC");
-/// assert_eq!(nucs::casts::nucs_as_ambi(&dna), AmbiNuc::lit(b"CATATTAC"));
+/// let dna = Nuc::arr(b"CATATTAC");
+/// assert_eq!(nucs::casts::nucs_as_ambi(&dna), AmbiNuc::arr(b"CATATTAC"));
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "unsafe")))]
 #[must_use]
@@ -66,10 +66,10 @@ pub fn nucs_as_ambi(nucs: &[Nuc]) -> &[AmbiNuc] {
 /// ```
 /// use nucs::{AmbiNuc, Nuc};
 ///
-/// let dna = AmbiNuc::lit(b"CATATTAC");
-/// assert_eq!(nucs::casts::ambi_to_nucs(&dna).unwrap(), Nuc::lit(b"CATATTAC"));
+/// let dna = AmbiNuc::arr(b"CATATTAC");
+/// assert_eq!(nucs::casts::ambi_to_nucs(&dna).unwrap(), Nuc::arr(b"CATATTAC"));
 ///
-/// let dna = AmbiNuc::lit(b"CATTY");
+/// let dna = AmbiNuc::arr(b"CATTY");
 /// assert!(nucs::casts::ambi_to_nucs(&dna).is_none());
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "unsafe")))]
@@ -103,13 +103,13 @@ pub fn ambi_to_nucs(nucs: &[AmbiNuc]) -> Option<&[Nuc]> {
 /// ```
 /// use nucs::{AmbiNuc, DnaSlice, Nuc};
 ///
-/// let mut dna = AmbiNuc::lit(b"CATATTAC");
+/// let mut dna = AmbiNuc::arr(b"CATATTAC");
 /// if let Some(nucs) = nucs::casts::ambi_to_nucs_mut(&mut dna) {
 ///     nucs[7] = Nuc::G;
 /// }
-/// assert_eq!(dna, AmbiNuc::lit(b"CATATTAG"));
+/// assert_eq!(dna, AmbiNuc::arr(b"CATATTAG"));
 ///
-/// let mut dna = AmbiNuc::lit(b"CATTY");
+/// let mut dna = AmbiNuc::arr(b"CATTY");
 /// assert!(nucs::casts::ambi_to_nucs_mut(&mut dna).is_none());
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "unsafe")))]
@@ -153,8 +153,8 @@ mod tests {
         assert_eq!(nucs_as_ambi(&[] as &[Nuc]), &[] as &[AmbiNuc]);
 
         assert_eq!(
-            nucs_as_ambi(&Nuc::lit(b"GATTACA")),
-            AmbiNuc::lit(b"GATTACA")
+            nucs_as_ambi(&Nuc::arr(b"GATTACA")),
+            AmbiNuc::arr(b"GATTACA")
         );
     }
 
@@ -163,11 +163,11 @@ mod tests {
         assert_eq!(ambi_to_nucs(&[] as &[AmbiNuc]).unwrap(), &[] as &[Nuc]);
 
         assert_eq!(
-            ambi_to_nucs(&AmbiNuc::lit(b"CATTAG")).unwrap(),
-            Nuc::lit(b"CATTAG")
+            ambi_to_nucs(&AmbiNuc::arr(b"CATTAG")).unwrap(),
+            Nuc::arr(b"CATTAG")
         );
 
-        assert_eq!(ambi_to_nucs(&AmbiNuc::lit(b"CATSTAG")), None);
+        assert_eq!(ambi_to_nucs(&AmbiNuc::arr(b"CATSTAG")), None);
     }
 
     #[test]
@@ -177,15 +177,15 @@ mod tests {
             &[] as &[Nuc]
         );
 
-        let mut buffer = AmbiNuc::lit(b"CATTAG");
+        let mut buffer = AmbiNuc::arr(b"CATTAG");
         let nuc_buf = ambi_to_nucs_mut(&mut buffer).unwrap();
         nuc_buf[0] = Nuc::A;
         nuc_buf[1] = Nuc::C;
         nuc_buf[5] = Nuc::T;
-        assert_eq!(nuc_buf, Nuc::lit(b"ACTTAT"));
-        assert_eq!(buffer, AmbiNuc::lit(b"ACTTAT"));
+        assert_eq!(nuc_buf, Nuc::arr(b"ACTTAT"));
+        assert_eq!(buffer, AmbiNuc::arr(b"ACTTAT"));
 
-        assert_eq!(ambi_to_nucs_mut(&mut AmbiNuc::lit(b"CATSTAG")), None);
+        assert_eq!(ambi_to_nucs_mut(&mut AmbiNuc::arr(b"CATSTAG")), None);
     }
 
     // Like any_ambi_dna(...) except convertible to `&[Nuc]` more than half the time.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -15,8 +15,8 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, Nuc};
     ///
-    /// let complement = Nuc::lit(b"GATTACA").into_iter().revcomped();
-    /// assert!(complement.eq(Nuc::lit(b"TGTAATC")));
+    /// let complement = Nuc::arr(b"GATTACA").into_iter().revcomped();
+    /// assert!(complement.eq(Nuc::arr(b"TGTAATC")));
     /// ```
     fn revcomped<N>(self) -> Complemented<N, std::iter::Rev<Self>>
     where
@@ -35,8 +35,8 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, Nuc};
     ///
-    /// let complement = Nuc::lit(b"GATTACA").into_iter().complemented();
-    /// assert!(complement.eq(Nuc::lit(b"CTAATGT")));
+    /// let complement = Nuc::arr(b"GATTACA").into_iter().complemented();
+    /// assert!(complement.eq(Nuc::arr(b"CTAATGT")));
     /// ```
     fn complemented<N>(self) -> Complemented<N, Self>
     where
@@ -59,9 +59,9 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"GATTACA");
+    /// let mut dna = Nuc::arr(b"GATTACA");
     /// dna.iter_mut().revcomp();
-    /// assert_eq!(dna, Nuc::lit(b"TGTAATC"));
+    /// assert_eq!(dna, Nuc::arr(b"TGTAATC"));
     /// ```
     fn revcomp<N>(mut self)
     where
@@ -86,9 +86,9 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"GATTACA");
+    /// let mut dna = Nuc::arr(b"GATTACA");
     /// dna.iter_mut().complement();
-    /// assert_eq!(dna, Nuc::lit(b"CTAATGT"));
+    /// assert_eq!(dna, Nuc::arr(b"CTAATGT"));
     /// ```
     fn complement<'a, N>(self)
     where
@@ -110,7 +110,7 @@ pub trait DnaIter: Iterator {
     /// use nucs::{DnaIter, Nuc};
     /// use Nuc::{A, C, G, T};
     ///
-    /// let codons = Nuc::lit(b"GATTACA").into_iter().codons();
+    /// let codons = Nuc::arr(b"GATTACA").into_iter().codons();
     /// assert!(codons.eq([
     ///     [G, A, T],
     ///     [T, A, C],
@@ -135,7 +135,7 @@ pub trait DnaIter: Iterator {
     /// use nucs::{DnaIter, Nuc};
     /// use Nuc::{A, C, G, T};
     ///
-    /// let codons = Nuc::lit(b"GATTACA").into_iter().trimmed_to_codon();
+    /// let codons = Nuc::arr(b"GATTACA").into_iter().trimmed_to_codon();
     /// assert!(codons.eq([
     ///     G, A, T,
     ///     T, A, C,
@@ -163,7 +163,7 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, NCBI1, Nuc, Seq};
     ///
-    /// let peptide: Seq<Vec<_>> = Nuc::lit(b"TATGCGAGAAAC")
+    /// let peptide: Seq<Vec<_>> = Nuc::arr(b"TATGCGAGAAAC")
     ///     .into_iter()
     ///     .translated_by(NCBI1)
     ///     .collect();
@@ -188,7 +188,7 @@ pub trait DnaIter: Iterator {
     /// ```
     /// use nucs::{DnaIter, Nuc};
     ///
-    /// let dna = Nuc::lit(b"GATTACA").into_iter().display();
+    /// let dna = Nuc::arr(b"GATTACA").into_iter().display();
     /// assert_eq!(format!("{dna:#4}"), "GATT\nACA");
     /// ```
     fn display<N>(&self) -> Display<Self>
@@ -364,7 +364,7 @@ where
 /// ```
 /// use nucs::{Amino, DnaIter, Nuc};
 ///
-/// let dna = Nuc::lit(b"GATTACA").into_iter().display();
+/// let dna = Nuc::arr(b"GATTACA").into_iter().display();
 ///
 /// // The default formatting just prints everything on a single line:
 /// assert_eq!(dna.to_string(), "GATTACA");
@@ -378,7 +378,7 @@ where
 /// assert_eq!(format!("{dna:#4?}"), "GATT\nACA");
 ///
 /// // `Amino`s are supported too, though there's not currently a helper trait for that.
-/// let peptide = Amino::lit(b"PEPTIDE");
+/// let peptide = Amino::arr(b"PEPTIDE");
 /// let peptide = nucs::iter::Display::new(peptide);
 /// assert_eq!(format!("{peptide:#4}"), "PEPT\nIDE");
 /// ```
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn complemented_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         let vals: Seq<Vec<_>> = anon_vals(dna).into_iter().complemented().collect();
         assert_eq!(vals, "TTTTGGGCCA");
         let refs: Seq<Vec<_>> = anon_refs(&dna).into_iter().complemented().collect();
@@ -540,9 +540,9 @@ mod tests {
 
     #[test]
     fn complement_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         anon_muts(&mut dna).into_iter().complement();
-        assert_eq!(dna, Nuc::lit(b"TTTTGGGCCA"));
+        assert_eq!(dna, Nuc::arr(b"TTTTGGGCCA"));
     }
 
     #[test]
@@ -554,14 +554,14 @@ mod tests {
             iter
         }
 
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         anon_muts(&mut dna).into_iter().revcomp();
-        assert_eq!(dna, Nuc::lit(b"ACCGGGTTTT"));
+        assert_eq!(dna, Nuc::arr(b"ACCGGGTTTT"));
     }
 
     #[test]
     fn codons_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         let vals: Vec<_> = anon_vals(dna).into_iter().codons().map(Seq).collect();
         assert_eq!(vals, ["AAA", "ACC", "CGG"]);
         let refs: Vec<_> = anon_refs(&dna).into_iter().codons().map(Seq).collect();
@@ -603,7 +603,7 @@ mod tests {
             iter
         }
 
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         let vals: Seq<Vec<_>> = anon_vals(dna).into_iter().trimmed_to_codon().collect();
         assert_eq!(vals.to_string(), "AAAACCCGG");
         let refs: Seq<Vec<_>> = anon_refs(&dna).into_iter().trimmed_to_codon().collect();
@@ -614,7 +614,7 @@ mod tests {
 
     #[test]
     fn translate_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         let vals: Seq<Vec<_>> = anon_vals(dna).into_iter().translated_by(NCBI1).collect();
         assert_eq!(vals, "KTR");
         let refs: Seq<Vec<_>> = anon_refs(&dna).into_iter().translated_by(NCBI1).collect();
@@ -640,7 +640,7 @@ mod tests {
             iter
         }
 
-        let dna = Nuc::lit(b"AAAACCCGGT");
+        let dna = Nuc::arr(b"AAAACCCGGT");
         let vals = anon_vals(dna).into_iter().display();
         assert_eq!(vals.to_string(), "AAAACCCGGT");
         let refs = anon_refs(&dna).into_iter().display();
@@ -649,24 +649,24 @@ mod tests {
 
     #[test]
     fn revcomp() {
-        let mut dna = Nuc::lit(b"");
+        let mut dna = Nuc::arr(b"");
         dna.iter_mut().revcomp(); // just sanity check a lack of panics
 
-        let mut dna = Nuc::lit(b"A");
+        let mut dna = Nuc::arr(b"A");
         dna.iter_mut().revcomp();
-        assert_eq!(dna, Nuc::lit(b"T"));
+        assert_eq!(dna, Nuc::arr(b"T"));
 
-        let mut dna = Nuc::lit(b"AC");
+        let mut dna = Nuc::arr(b"AC");
         dna.iter_mut().revcomp();
-        assert_eq!(dna, Nuc::lit(b"GT"));
+        assert_eq!(dna, Nuc::arr(b"GT"));
 
-        let mut dna = Nuc::lit(b"ACT");
+        let mut dna = Nuc::arr(b"ACT");
         dna.iter_mut().revcomp();
-        assert_eq!(dna, Nuc::lit(b"AGT"));
+        assert_eq!(dna, Nuc::arr(b"AGT"));
 
-        let mut dna = Nuc::lit(b"GACT");
+        let mut dna = Nuc::arr(b"GACT");
         dna.iter_mut().revcomp();
-        assert_eq!(dna, Nuc::lit(b"AGTC"));
+        assert_eq!(dna, Nuc::arr(b"AGTC"));
     }
 
     #[test]
@@ -680,7 +680,7 @@ mod tests {
         }
 
         // Deliberately doing odd.
-        let mut dna = Nuc::lit(b"ACATTAG");
+        let mut dna = Nuc::arr(b"ACATTAG");
         dna.each_mut()
             .map(Some)
             .map(SingleUseMut)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! assert_eq!(dna, "CATGAG");
 //!
 //! // For convenience, there's a helper to build const literals:
-//! const CAT: &[Nuc] = &Nuc::lit(b"CAT");
+//! const CAT: &[Nuc] = &Nuc::arr(b"CAT");
 //! assert!(dna.starts_with(CAT));
 //!
 //! // `Seq` is a wrapper to add convenience features to `Vec`-like collections
@@ -71,7 +71,7 @@
 //! // `Nuc`s can be composed into `AmbiNuc`s...
 //! assert_eq!(C | A | T, AmbiNuc::H);
 //! // ...which can be decomposed back into `Nuc`s
-//! let dna = AmbiNuc::lit(b"STRAYGYMNAST");
+//! let dna = AmbiNuc::arr(b"STRAYGYMNAST");
 //! assert!(dna[0].iter().eq([C, G]));
 //! assert!(dna[1].iter().eq([T]));
 //! assert!(dna[8].iter().eq(Nuc::ALL));
@@ -79,18 +79,18 @@
 //! // Both concrete and ambiguous amino acids are supported as well:
 //! use nucs::{Amino, AmbiAmino};
 //!
-//! // `Seq(T::lit(...))` is common so there's a shorthand for it:
+//! // `Seq(T::arr(...))` is common so there's a shorthand for it:
 //! let peptide = Amino::seq(b"KITTY*PAWS");
 //! assert_eq!(format!("{peptide:#5}"), "KITTY\n*PAWS");
 //!
 //! assert_eq!(Amino::I | Amino::L, AmbiAmino::J);
-//! assert!((Amino::C | Amino::A | Amino::T).iter().eq(Amino::lit(b"ACT")));
+//! assert!((Amino::C | Amino::A | Amino::T).iter().eq(Amino::arr(b"ACT")));
 //!
 //! // And it's easy to translate DNA into peptides:
 //! use nucs::NCBI1; // see `nucs::translation` for other genetic codes
 //!
 //! // Iterators support translation:
-//! let mut infinite_peptide = Nuc::lit(b"CAT")
+//! let mut infinite_peptide = Nuc::arr(b"CAT")
 //!     .into_iter()
 //!     .cycle()
 //!     .translated_by(NCBI1);

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -27,7 +27,7 @@ pub enum Nuc {
 
 impl Nuc {
     /// All [`Nuc`]s sorted in ascending order
-    pub const ALL: [Self; 4] = Self::lit(b"ACGT");
+    pub const ALL: [Self; 4] = Self::arr(b"ACGT");
 
     /// Swap [`A`](Self::A) and [`T`](Self::T), as well as [`C`](Self::C) and [`G`](Self::G).
     ///
@@ -116,7 +116,7 @@ impl Nuc {
     /// ```
     /// use nucs::Nuc;
     ///
-    /// let dna1 = Nuc::lit(b"TACT");
+    /// let dna1 = Nuc::arr(b"TACT");
     /// // ...is shorthand for...
     /// use Nuc::{T, A, C};
     /// let dna2 = [T, A, C, T];
@@ -130,7 +130,7 @@ impl Nuc {
     /// because the returned array must have the same length.
     #[must_use]
     #[track_caller]
-    pub const fn lit<const N: usize>(literal: &[u8; N]) -> [Nuc; N] {
+    pub const fn arr<const N: usize>(literal: &[u8; N]) -> [Nuc; N] {
         let mut nucs = [Self::A; N];
         let mut i = 0;
         while i < literal.len() {
@@ -165,7 +165,7 @@ impl Nuc {
     #[must_use]
     #[track_caller]
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Nuc; N]> {
-        Seq(Self::lit(literal))
+        Seq(Self::arr(literal))
     }
 }
 
@@ -267,7 +267,7 @@ pub enum AmbiNuc {
 
 impl AmbiNuc {
     /// All [`AmbiNuc`]s sorted in ascending order
-    pub const ALL: [Self; 15] = Self::lit(b"ACMGRSVTWYHKDBN");
+    pub const ALL: [Self; 15] = Self::arr(b"ACMGRSVTWYHKDBN");
 
     /// Return ambiguous nucleotide containing complements for each potential value.
     ///
@@ -405,7 +405,7 @@ impl AmbiNuc {
     /// ```
     /// use nucs::{AmbiNuc, Nuc};
     ///
-    /// assert!(AmbiNuc::B.iter().eq(Nuc::lit(b"CGT")));
+    /// assert!(AmbiNuc::B.iter().eq(Nuc::arr(b"CGT")));
     ///
     /// assert_eq!(Vec::from_iter(AmbiNuc::B), AmbiNuc::B.expansions());
     /// ```
@@ -423,7 +423,7 @@ impl AmbiNuc {
     /// ```
     /// use nucs::{AmbiNuc, Nuc};
     ///
-    /// assert_eq!(AmbiNuc::B.expansions(), Nuc::lit(b"CGT"));
+    /// assert_eq!(AmbiNuc::B.expansions(), Nuc::arr(b"CGT"));
     /// assert_eq!(Nuc::C | Nuc::G | Nuc::T, AmbiNuc::B);
     /// ```
     #[must_use]
@@ -457,7 +457,7 @@ impl AmbiNuc {
     /// ```
     /// use nucs::AmbiNuc;
     ///
-    /// let dna1 = AmbiNuc::lit(b"NASTYGRAM");
+    /// let dna1 = AmbiNuc::arr(b"NASTYGRAM");
     /// // ...is shorthand for...
     /// use AmbiNuc::{N, A, S, T, Y, G, R, M};
     /// let dna2 = [N, A, S, T, Y, G, R, A, M];
@@ -471,7 +471,7 @@ impl AmbiNuc {
     /// because the returned array must have the same length.
     #[must_use]
     #[track_caller]
-    pub const fn lit<const N: usize>(literal: &[u8; N]) -> [AmbiNuc; N] {
+    pub const fn arr<const N: usize>(literal: &[u8; N]) -> [AmbiNuc; N] {
         let mut nucs = [Self::A; N];
         let mut i = 0;
         while i < literal.len() {
@@ -506,7 +506,7 @@ impl AmbiNuc {
     #[must_use]
     #[track_caller]
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[AmbiNuc; N]> {
-        Seq(Self::lit(literal))
+        Seq(Self::arr(literal))
     }
 
     pub(crate) fn from_u8(byte: u8) -> Option<Self> {
@@ -775,8 +775,8 @@ impl Symbol for Nuc {
         Self::to_ascii(self)
     }
 
-    fn lit<const N: usize>(literal: &[u8; N]) -> [Self; N] {
-        Self::lit(literal)
+    fn arr<const N: usize>(literal: &[u8; N]) -> [Self; N] {
+        Self::arr(literal)
     }
 
     fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Self; N]> {
@@ -800,8 +800,8 @@ impl Symbol for AmbiNuc {
         Self::to_ascii(self)
     }
 
-    fn lit<const N: usize>(literal: &[u8; N]) -> [Self; N] {
-        Self::lit(literal)
+    fn arr<const N: usize>(literal: &[u8; N]) -> [Self; N] {
+        Self::arr(literal)
     }
 
     fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Self; N]> {

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -87,7 +87,7 @@ impl<T: ?Sized> Seq<T> {
     /// ```
     /// use nucs::{Nuc, Seq};
     ///
-    /// let dna = Nuc::lit(b"ACTGACTG");
+    /// let dna = Nuc::arr(b"ACTGACTG");
     /// let partial_dna = Seq::wrap(&dna[3..6]);
     /// assert_eq!(partial_dna, "GAC");
     /// ```
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn sanity_check_that_seq_works_with_vecs() {
-        let dna = Seq(Nuc::lit(b"ACGT").to_vec());
+        let dna = Seq(Nuc::arr(b"ACGT").to_vec());
         assert_eq!(dna, "ACGT");
         let peptide = dna.translated_to_vec_by(NCBI1);
         assert_eq!(peptide, "T");
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn sanity_check_that_seq_works_with_slices() {
-        let dna = Seq::wrap(const { &Nuc::lit(b"ACGT") });
+        let dna = Seq::wrap(const { &Nuc::arr(b"ACGT") });
         assert_eq!(dna, "ACGT");
         let peptide = dna.translated_to_vec_by(NCBI1);
         assert_eq!(peptide, "T");
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn sanity_check_that_seq_works_with_vecdeques() {
         type VdSeq<T> = Seq<VecDeque<T>>;
-        let dna = VdSeq::from_iter(Nuc::lit(b"ACGT"));
+        let dna = VdSeq::from_iter(Nuc::arr(b"ACGT"));
         assert_eq!(dna, "ACGT");
         let peptide: VdSeq<_> = dna.translated_by(NCBI1);
         assert_eq!(peptide, "T");

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -27,7 +27,7 @@ pub trait DnaSlice {
     ///     [T, A, G],
     ///     [A, C, T],
     /// ];
-    /// assert_eq!(codons.as_flat_dna(), Nuc::lit(b"CATTAGACT"));
+    /// assert_eq!(codons.as_flat_dna(), Nuc::arr(b"CATTAGACT"));
     /// ```
     fn as_flat_dna(&self) -> &[Self::Nuc] {
         self.as_codons().as_flattened()
@@ -70,7 +70,7 @@ pub trait DnaSlice {
     /// use nucs::{DnaSlice, Nuc};
     /// use Nuc::{A, C, T};
     ///
-    /// let dna = Nuc::lit(b"CATATTAC");
+    /// let dna = Nuc::arr(b"CATATTAC");
     /// assert_eq!(
     ///     dna.as_codons(),
     ///     [[C, A, T], [A, T, T]]
@@ -89,11 +89,11 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"CATATTAC");
+    /// let mut dna = Nuc::arr(b"CATATTAC");
     /// let codons = dna.as_codons_mut();
     /// // Set the second codon's first nucleotide...
     /// codons[1][0] = Nuc::G;
-    /// assert_eq!(dna, Nuc::lit(b"CATGTTAC"));
+    /// assert_eq!(dna, Nuc::arr(b"CATGTTAC"));
     /// ```
     fn as_codons_mut(&mut self) -> &mut [[Self::Nuc; 3]] {
         self.as_flat_dna_mut().as_chunks_mut().0
@@ -109,7 +109,7 @@ pub trait DnaSlice {
     /// use nucs::{DnaSlice, Nuc};
     /// use Nuc::{A, C, T};
     ///
-    /// let dna = Nuc::lit(b"CATATTAC");
+    /// let dna = Nuc::arr(b"CATATTAC");
     /// assert_eq!(
     ///     dna.as_rcodons(),
     ///     [[T, A, T], [T, A, C]]
@@ -128,11 +128,11 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"CATATTAC");
+    /// let mut dna = Nuc::arr(b"CATATTAC");
     /// let codons = dna.as_rcodons_mut();
     /// // Set the second codon's first nucleotide...
     /// codons[1][0] = Nuc::G;
-    /// assert_eq!(dna, Nuc::lit(b"CATATGAC"));
+    /// assert_eq!(dna, Nuc::arr(b"CATATGAC"));
     /// ```
     fn as_rcodons_mut(&mut self) -> &mut [[Self::Nuc; 3]] {
         self.as_flat_dna_mut().as_rchunks_mut().1
@@ -185,7 +185,7 @@ pub trait DnaSlice {
     /// use nucs::{DnaSlice, Nuc};
     /// use Nuc::{A, C, T};
     ///
-    /// let dna = Nuc::lit(b"ACATATTAC");
+    /// let dna = Nuc::arr(b"ACATATTAC");
     /// assert_eq!(
     ///     dna.reading_frames(),
     ///     [
@@ -209,7 +209,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
     ///
-    /// let peptide: Seq<Vec<_>> = Nuc::lit(b"TATGCGAGAAAC")
+    /// let peptide: Seq<Vec<_>> = Nuc::arr(b"TATGCGAGAAAC")
     ///     .translated_by(NCBI1)
     ///     .collect();
     /// assert_eq!(peptide, "YARN");
@@ -230,7 +230,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
     ///
-    /// let dna = Nuc::lit(b"TATGCGAGAAACA");
+    /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let peptide = dna.translated_to_vec_by(NCBI1);
     /// assert_eq!(Seq(peptide), "YARN");
     /// ```
@@ -251,7 +251,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
     ///
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let peptide = dna.rc_translated_to_vec_by(NCBI1);
     /// assert_eq!(Seq(peptide), "FAST*RC");
     /// ```
@@ -276,7 +276,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
     ///
-    /// let dna = Nuc::lit(b"TATGCGAGAAACA");
+    /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let peptide: [_; 4] = dna.translated_to_array_by(NCBI1);
     /// assert_eq!(Seq(peptide), "YARN");
     /// ```
@@ -300,7 +300,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
     ///
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let peptide: [_; 7] = dna.rc_translated_to_array_by(NCBI1);
     /// assert_eq!(Seq(peptide), "FAST*RC");
     /// ```
@@ -326,7 +326,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
     ///
-    /// let dna = Nuc::lit(b"TATGCGAGAAACA");
+    /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let mut peptide: [_; 4] = Default::default();
     /// dna.translated_to_buf_by(NCBI1, &mut peptide);
     /// assert_eq!(Seq(peptide), "YARN");
@@ -364,7 +364,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
     ///
-    /// let dna = AmbiNuc::lit(b"NGCACCGCTAGGTACTGGCGAA");
+    /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let mut peptide: [_; 7] = Default::default();
     /// dna.rc_translated_to_buf_by(NCBI1, &mut peptide);
     /// assert_eq!(Seq(peptide), "FAST*RC");
@@ -398,7 +398,7 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, Nuc};
     ///
-    /// let dna = Nuc::lit(b"CATATTAC");
+    /// let dna = Nuc::arr(b"CATATTAC");
     /// assert_eq!(dna.display().to_string(), "CATATTAC");
     /// assert_eq!(format!("{:#4}", dna.display()), "CATA\nTTAC");
     /// ```
@@ -419,8 +419,8 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, Nuc};
     ///
-    /// let dna = Nuc::lit(b"CATATTAC");
-    /// assert_eq!(dna.as_ambi_nucs(), AmbiNuc::lit(b"CATATTAC"));
+    /// let dna = Nuc::arr(b"CATATTAC");
+    /// assert_eq!(dna.as_ambi_nucs(), AmbiNuc::arr(b"CATATTAC"));
     /// ```
     #[cfg(feature = "unsafe")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unsafe")))]
@@ -443,10 +443,10 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, Nuc};
     ///
-    /// let dna = AmbiNuc::lit(b"CATATTAC");
-    /// assert_eq!(dna.to_nucs().unwrap(), Nuc::lit(b"CATATTAC"));
+    /// let dna = AmbiNuc::arr(b"CATATTAC");
+    /// assert_eq!(dna.to_nucs().unwrap(), Nuc::arr(b"CATATTAC"));
     ///
-    /// let dna = AmbiNuc::lit(b"CATTY");
+    /// let dna = AmbiNuc::arr(b"CATTY");
     /// assert!(dna.to_nucs().is_none());
     /// ```
     #[cfg(feature = "unsafe")]
@@ -470,13 +470,13 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{AmbiNuc, DnaSlice, Nuc};
     ///
-    /// let mut dna = AmbiNuc::lit(b"CATATTAC");
+    /// let mut dna = AmbiNuc::arr(b"CATATTAC");
     /// if let Some(nucs) = dna.to_nucs_mut() {
     ///     nucs[7] = Nuc::G;
     /// }
-    /// assert_eq!(dna, AmbiNuc::lit(b"CATATTAG"));
+    /// assert_eq!(dna, AmbiNuc::arr(b"CATATTAG"));
     ///
-    /// let mut dna = AmbiNuc::lit(b"CATTY");
+    /// let mut dna = AmbiNuc::arr(b"CATTY");
     /// assert!(dna.to_nucs_mut().is_none());
     /// ```
     #[cfg(feature = "unsafe")]
@@ -492,9 +492,9 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"CATATTAC");
+    /// let mut dna = Nuc::arr(b"CATATTAC");
     /// dna.complement();
-    /// assert_eq!(dna, Nuc::lit(b"GTATAATG"));
+    /// assert_eq!(dna, Nuc::arr(b"GTATAATG"));
     /// ```
     fn complement(&mut self) {
         self.as_flat_dna_mut().iter_mut().complement();
@@ -507,9 +507,9 @@ pub trait DnaSlice {
     /// ```
     /// use nucs::{DnaSlice, Nuc};
     ///
-    /// let mut dna = Nuc::lit(b"CATATTAC");
+    /// let mut dna = Nuc::arr(b"CATATTAC");
     /// dna.revcomp();
-    /// assert_eq!(dna, Nuc::lit(b"GTAATATG"));
+    /// assert_eq!(dna, Nuc::arr(b"GTAATATG"));
     /// ```
     fn revcomp(&mut self) {
         self.as_flat_dna_mut().iter_mut().revcomp();
@@ -560,7 +560,7 @@ mod tests {
 
     #[test]
     fn translated_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         let peptide: Seq<Vec<_>> = anon_slice(&dna).translated_by(NCBI1).collect();
         assert_eq!(peptide, "KTR");
         let peptide: Seq<Vec<_>> = anon_mut_slice(&mut dna).translated_by(NCBI1).collect();
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn display_type_inference() {
-        let mut dna = Nuc::lit(b"AAAACCCGGT");
+        let mut dna = Nuc::arr(b"AAAACCCGGT");
         assert_eq!(anon_slice(&dna).display().to_string(), "AAAACCCGGT");
         assert_eq!(anon_mut_slice(&mut dna).display().to_string(), "AAAACCCGGT");
     }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -55,7 +55,7 @@ pub trait Symbol:
     /// This is just intended to be a convenience method for testing.
     #[must_use]
     #[track_caller]
-    fn lit<const N: usize>(literal: &[u8; N]) -> [Self; N];
+    fn arr<const N: usize>(literal: &[u8; N]) -> [Self; N];
 
     /// Construct [`Seq`]-wrapped array from literal without allocating.
     ///

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -34,9 +34,9 @@ pub trait GeneticCode {
     ///    [A, T, G] => Amino::W,
     ///    _ => Amino::Stop,
     /// };
-    /// assert_eq!(genetic_code.translate_rc(Nuc::lit(b"CAT")), Amino::W);
-    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::lit(b"CAT")), AmbiAmino::W);
-    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::lit(b"ANT")), AmbiAmino::Stop);
+    /// assert_eq!(genetic_code.translate_rc(Nuc::arr(b"CAT")), Amino::W);
+    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::arr(b"CAT")), AmbiAmino::W);
+    /// assert_eq!(genetic_code.translate_rc(AmbiNuc::arr(b"ANT")), AmbiAmino::Stop);
     /// ```
     fn translate_rc<N: Nucleotide>(&self, codon: [N; 3]) -> N::Amino {
         N::translate_rc(self, codon)
@@ -242,7 +242,7 @@ impl ConcreteLookup {
     /// use nucs::{Amino, NCBI1};
     /// use nucs::translation::ConcreteLookup;
     ///
-    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let table = Amino::arr(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
     /// let lookup = ConcreteLookup::from_table(&table);
     /// assert_eq!(lookup.to_table(), table);
     /// ```
@@ -275,7 +275,7 @@ impl ConcreteLookup {
     /// use nucs::translation::{ConcreteLookup, GeneticCode};
     /// use Nuc::{A, C, G, T};
     ///
-    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let table = Amino::arr(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
     /// let lookup = ConcreteLookup::from_table(&table);
     /// assert_eq!((&lookup).translate([A, T, G]), Amino::Q);
     /// let lookup_rc = lookup.reverse_complement();
@@ -407,7 +407,7 @@ impl AmbiLookup {
     /// use nucs::translation::{ConcreteLookup, GeneticCode};
     /// use Nuc::{A, C, G, T};
     ///
-    /// let table = Amino::lit(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
+    /// let table = Amino::arr(b"ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRSTUVWY*ACDEFGHIKLMNOPQRS*");
     /// let lookup = ConcreteLookup::from_table(&table).to_ambi_lookup();
     /// assert_eq!((&lookup).translate([A, T, G]), Amino::Q);
     /// let lookup_rc = lookup.reverse_complement();
@@ -681,9 +681,9 @@ mod tests {
 
     #[test]
     fn fast_lookup_reverse_complement() {
-        let dna = Nuc::lit(b"ATCTTCGGGGGGAATTAAAAACTAATAAAGTTCAACAATGGTTGGCATCTCTTCCCGGGG");
+        let dna = Nuc::arr(b"ATCTTCGGGGGGAATTAAAAACTAATAAAGTTCAACAATGGTTGGCATCTCTTCCCGGGG");
         let peptide = dna.rc_translated_to_vec_by(NCBI1);
-        assert_eq!(peptide, Amino::lit(b"PREEMPTIVELY*FLIPPED"));
+        assert_eq!(peptide, Amino::arr(b"PREEMPTIVELY*FLIPPED"));
     }
 
     #[test]


### PR DESCRIPTION
I think abbreviating "literal" as `lit` is less common than abbreviating "array" as `arr`, so I'm hoping this will make the API a little clearer.