### PR TITLE
Tweak docs.rs settings to enable all features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ authors = [
 rust-version = "1.89"
 edition = "2024"
 
+[package.metadata.docs.rs]
+features = ["all"]
+
 [features]
 default = []
 all = ["proptest", "rand", "serde", "unsafe"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## Unreleased
+
+* Tweak [`docs.rs`](https://docs.rs/nucs/latest/nucs/) settings to build with all features
+  again. (#44)
+
 ## Version 0.3.0 (2026-04-10)
 
 * Loads of adjustments to translation. There are now methods on `DnaSlice` and `Seq` to perform


### PR DESCRIPTION
This gets feature-dependent APIs to show up on `docs.rs` again.