### PR TITLE
Rename `DnaSlice` to `DnaSliceExt`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Its design is based off of my experience using and helping maintain
 * ...tries to be consistent with Zipf's law of abbreviation when naming things.
 
 ```rust
-use nucs::{Dna, DnaSlice, NCBI1, Nuc};
+use nucs::{Dna, DnaSliceExt, NCBI1, Nuc};
 
 let mut dna: Dna = "ACACACATATCTTACGCTTAGGAAATCTGACCCGAA"
     .parse().unwrap();

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 * `Seq` now wraps subslices so e.g. `assert_eq!(&dna[2..], "ATCG");` now works. (#46)
 * `Seq` now has limited support for `ToOwned`, `Borrow` and `BorrowMut`. (#47)
+* `DnaSlice` was renamed to `DnaSliceExt` to reflect that it's an extension trait. (#48)
 
 ## Version 0.3.1 (2026-04-20)
 

--- a/benches/translation.rs
+++ b/benches/translation.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-use nucs::{AmbiNuc, DnaSlice, NCBI1, Nuc};
+use nucs::{AmbiNuc, DnaSliceExt, NCBI1, Nuc};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::from_os_rng();

--- a/src/casts.rs
+++ b/src/casts.rs
@@ -31,7 +31,7 @@ fn is_representable_as_nucs(nucs: &[AmbiNuc]) -> bool {
 
 /// Cast [`&[Nuc]`](slice) to [`&[AmbiNuc]`](slice).
 ///
-/// You may wish to use [`DnaSlice::as_ambi_nucs`](crate::DnaSlice::as_ambi_nucs) instead.
+/// You may wish to use [`DnaSliceExt::as_ambi_nucs`](crate::DnaSliceExt::as_ambi_nucs) instead.
 ///
 /// # Examples
 ///
@@ -59,7 +59,7 @@ pub fn nucs_as_ambi(nucs: &[Nuc]) -> &[AmbiNuc] {
 ///
 /// [`None`] is returned if any nucleotides are degenerate (inexpressible by [`Nuc`]).
 ///
-/// You may wish to use [`DnaSlice::to_nucs`](crate::DnaSlice::to_nucs) instead.
+/// You may wish to use [`DnaSliceExt::to_nucs`](crate::DnaSliceExt::to_nucs) instead.
 ///
 /// # Examples
 ///
@@ -96,12 +96,12 @@ pub fn ambi_to_nucs(nucs: &[AmbiNuc]) -> Option<&[Nuc]> {
 ///
 /// [`None`] is returned if any nucleotides are degenerate (inexpressible by [`Nuc`]).
 ///
-/// You may wish to use [`DnaSlice::to_nucs_mut`](crate::DnaSlice::to_nucs_mut) instead.
+/// You may wish to use [`DnaSliceExt::to_nucs_mut`](crate::DnaSliceExt::to_nucs_mut) instead.
 ///
 /// # Examples
 ///
 /// ```
-/// use nucs::{AmbiNuc, DnaSlice, Nuc};
+/// use nucs::{AmbiNuc, DnaSliceExt, Nuc};
 ///
 /// let mut dna = AmbiNuc::arr(b"CATATTAC");
 /// if let Some(nucs) = nucs::casts::ambi_to_nucs_mut(&mut dna) {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -503,7 +503,7 @@ mod tests {
     use proptest::proptest;
 
     use crate::proptest::any_dna;
-    use crate::{Dna, DnaSlice, NCBI1, Nuc, Seq};
+    use crate::{Dna, DnaSliceExt, NCBI1, Nuc, Seq};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! // `DnaSlice` supplies helpers for working with slices:
 //! // (whether or not they're wrapped in `Seq`)
-//! use nucs::DnaSlice;
+//! use nucs::DnaSliceExt;
 //! use Nuc::{A, C, G, T};
 //! assert_eq!(
 //!     slice.reading_frames(),
@@ -148,7 +148,7 @@ pub use amino::{AmbiAmino, Amino};
 pub use iter::DnaIter;
 pub use nuc::{AmbiNuc, Nuc, Nucleotide};
 pub use seq::Seq;
-pub use slice::DnaSlice;
+pub use slice::DnaSliceExt;
 pub use symbol::Symbol;
 pub use translation::NCBI1;
 

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -851,7 +851,7 @@ impl crate::symbol::sealed::Sealed for AmbiNuc {
 
 #[cfg(test)]
 mod tests {
-    use crate::DnaSlice;
+    use crate::DnaSliceExt;
 
     use super::*;
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -8,7 +8,7 @@ use ref_cast::{RefCastCustom, ref_cast_custom};
 
 use crate::error::ParseSeqError;
 use crate::translation::GeneticCode;
-use crate::{DnaIter, DnaSlice, Nucleotide, Symbol};
+use crate::{DnaIter, DnaSliceExt, Nucleotide, Symbol};
 
 /// Provides DNA/peptide ergonomics for collections.
 ///
@@ -81,7 +81,7 @@ impl<T: ?Sized> Seq<T> {
     ///
     /// Most of `Seq`'s features (e.g. [`Display`] impl or string comparisons) work for
     /// `&Seq<[T]>` but not `Seq<&[T]>`, so `Seq::wrap(slice)` should be prefered
-    /// over `Seq(slice)`. For convenience, there's also [`DnaSlice::as_seq`].
+    /// over `Seq(slice)`. For convenience, there's also [`DnaSliceExt::as_seq`].
     ///
     /// # Examples
     ///
@@ -99,7 +99,7 @@ impl<T: ?Sized> Seq<T> {
     ///
     /// Most of `Seq`'s features (e.g. [`Display`] impl or string comparisons) work for
     /// `&mut Seq<[T]>` but not `Seq<&mut [T]>`, so `Seq::wrap_mut(slice)` should be prefered
-    /// over `Seq(slice)`. For convenience, there's also [`DnaSlice::as_seq_mut`].
+    /// over `Seq(slice)`. For convenience, there's also [`DnaSliceExt::as_seq_mut`].
     ///
     /// # Examples
     ///
@@ -166,10 +166,10 @@ impl<T: ?Sized> Seq<T> {
     pub fn translated_to_array_by<S, G, const N: usize>(
         &self,
         genetic_code: G,
-    ) -> Seq<[<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino; N]>
+    ) -> Seq<[<<[S] as DnaSliceExt>::Nuc as Nucleotide>::Amino; N]>
     where
         T: AsRef<[S]>,
-        [S]: DnaSlice,
+        [S]: DnaSliceExt,
         G: GeneticCode,
     {
         Seq(self.0.as_ref().translated_to_array_by(genetic_code))
@@ -193,10 +193,10 @@ impl<T: ?Sized> Seq<T> {
     pub fn rc_translated_to_array_by<S, G, const N: usize>(
         &self,
         genetic_code: G,
-    ) -> Seq<[<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino; N]>
+    ) -> Seq<[<<[S] as DnaSliceExt>::Nuc as Nucleotide>::Amino; N]>
     where
         T: AsRef<[S]>,
-        [S]: DnaSlice,
+        [S]: DnaSliceExt,
         G: GeneticCode,
     {
         Seq(self.0.as_ref().rc_translated_to_array_by(genetic_code))
@@ -218,10 +218,10 @@ impl<T: ?Sized> Seq<T> {
     pub fn translated_to_vec_by<S, G>(
         &self,
         genetic_code: G,
-    ) -> Seq<Vec<<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino>>
+    ) -> Seq<Vec<<<[S] as DnaSliceExt>::Nuc as Nucleotide>::Amino>>
     where
         T: AsRef<[S]>,
-        [S]: DnaSlice,
+        [S]: DnaSliceExt,
         G: GeneticCode,
     {
         Seq(self.0.as_ref().translated_to_vec_by(genetic_code))
@@ -241,10 +241,10 @@ impl<T: ?Sized> Seq<T> {
     pub fn rc_translated_to_vec_by<S, G>(
         &self,
         genetic_code: G,
-    ) -> Seq<Vec<<<[S] as DnaSlice>::Nuc as Nucleotide>::Amino>>
+    ) -> Seq<Vec<<<[S] as DnaSliceExt>::Nuc as Nucleotide>::Amino>>
     where
         T: AsRef<[S]>,
-        [S]: DnaSlice,
+        [S]: DnaSliceExt,
         G: GeneticCode,
     {
         Seq(self.0.as_ref().rc_translated_to_vec_by(genetic_code))

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -10,7 +10,7 @@ use crate::symbol::sealed::Sealed;
 use crate::{AmbiNuc, Nuc};
 
 /// Helpers for working with slices of [`Nucleotide`]s.
-pub trait DnaSlice {
+pub trait DnaSliceExt {
     /// The type of [`Nucleotide`] this slice is made of.
     type Nuc: Nucleotide;
 
@@ -19,7 +19,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc, Seq};
+    /// use nucs::{DnaSliceExt, Nuc, Seq};
     /// use Nuc::{A, C, G, T};
     ///
     /// let codons = [
@@ -38,7 +38,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     /// use Nuc::{A, C, G, T};
     ///
     /// let mut codons = [
@@ -67,7 +67,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     /// use Nuc::{A, C, T};
     ///
     /// let dna = Nuc::arr(b"CATATTAC");
@@ -87,7 +87,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"CATATTAC");
     /// let codons = dna.as_codons_mut();
@@ -106,7 +106,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     /// use Nuc::{A, C, T};
     ///
     /// let dna = Nuc::arr(b"CATATTAC");
@@ -126,7 +126,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"CATATTAC");
     /// let codons = dna.as_rcodons_mut();
@@ -145,7 +145,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let dna = Nuc::seq(b"ACTGACTG");
     /// let partial_dna = dna[3..6].as_seq();
@@ -162,7 +162,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::seq(b"ACTGACTG");
     /// let partial_dna = dna[3..6].as_seq_mut();
@@ -182,7 +182,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     /// use Nuc::{A, C, T};
     ///
     /// let dna = Nuc::arr(b"ACATATTAC");
@@ -207,7 +207,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
+    /// use nucs::{DnaSliceExt, NCBI1, Nuc, Seq};
     ///
     /// let peptide: Seq<Vec<_>> = Nuc::arr(b"TATGCGAGAAAC")
     ///     .translated_by(NCBI1)
@@ -228,7 +228,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
+    /// use nucs::{DnaSliceExt, NCBI1, Nuc, Seq};
     ///
     /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let peptide = dna.translated_to_vec_by(NCBI1);
@@ -249,7 +249,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    /// use nucs::{AmbiNuc, DnaSliceExt, NCBI1, Seq};
     ///
     /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let peptide = dna.rc_translated_to_vec_by(NCBI1);
@@ -274,7 +274,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
+    /// use nucs::{DnaSliceExt, NCBI1, Nuc, Seq};
     ///
     /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let peptide: [_; 4] = dna.translated_to_array_by(NCBI1);
@@ -298,7 +298,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    /// use nucs::{AmbiNuc, DnaSliceExt, NCBI1, Seq};
     ///
     /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let peptide: [_; 7] = dna.rc_translated_to_array_by(NCBI1);
@@ -324,7 +324,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, NCBI1, Nuc, Seq};
+    /// use nucs::{DnaSliceExt, NCBI1, Nuc, Seq};
     ///
     /// let dna = Nuc::arr(b"TATGCGAGAAACA");
     /// let mut peptide: [_; 4] = Default::default();
@@ -362,7 +362,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, NCBI1, Seq};
+    /// use nucs::{AmbiNuc, DnaSliceExt, NCBI1, Seq};
     ///
     /// let dna = AmbiNuc::arr(b"NGCACCGCTAGGTACTGGCGAA");
     /// let mut peptide: [_; 7] = Default::default();
@@ -396,7 +396,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let dna = Nuc::arr(b"CATATTAC");
     /// assert_eq!(dna.display().to_string(), "CATATTAC");
@@ -417,7 +417,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, Nuc};
+    /// use nucs::{AmbiNuc, DnaSliceExt, Nuc};
     ///
     /// let dna = Nuc::arr(b"CATATTAC");
     /// assert_eq!(dna.as_ambi_nucs(), AmbiNuc::arr(b"CATATTAC"));
@@ -441,7 +441,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, Nuc};
+    /// use nucs::{AmbiNuc, DnaSliceExt, Nuc};
     ///
     /// let dna = AmbiNuc::arr(b"CATATTAC");
     /// assert_eq!(dna.to_nucs().unwrap(), Nuc::arr(b"CATATTAC"));
@@ -468,7 +468,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{AmbiNuc, DnaSlice, Nuc};
+    /// use nucs::{AmbiNuc, DnaSliceExt, Nuc};
     ///
     /// let mut dna = AmbiNuc::arr(b"CATATTAC");
     /// if let Some(nucs) = dna.to_nucs_mut() {
@@ -490,7 +490,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"CATATTAC");
     /// dna.complement();
@@ -505,7 +505,7 @@ pub trait DnaSlice {
     /// # Examples
     ///
     /// ```
-    /// use nucs::{DnaSlice, Nuc};
+    /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"CATATTAC");
     /// dna.revcomp();
@@ -516,7 +516,7 @@ pub trait DnaSlice {
     }
 }
 
-impl<N: Nucleotide> DnaSlice for [N] {
+impl<N: Nucleotide> DnaSliceExt for [N] {
     type Nuc = N;
 
     fn as_flat_dna(&self) -> &[N] {
@@ -528,7 +528,7 @@ impl<N: Nucleotide> DnaSlice for [N] {
     }
 }
 
-impl<N: Nucleotide> DnaSlice for [[N; 3]] {
+impl<N: Nucleotide> DnaSliceExt for [[N; 3]] {
     type Nuc = N;
 
     fn as_codons(&self) -> &[[N; 3]] {

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1,6 +1,6 @@
 //! Types related to translation of codons into amino acids.
 
-use crate::{AmbiAmino, AmbiNuc, Amino, DnaSlice, Nuc, Nucleotide};
+use crate::{AmbiAmino, AmbiNuc, Amino, DnaSliceExt, Nuc, Nucleotide};
 
 /// Trait representing any type that can be used to translate codons into amino acids.
 ///


### PR DESCRIPTION
`DnaSlice` is mostly used like an extension trait for slices, so it probably ought to have a name ending in `Ext` to communicate that.