### PR TITLE
Rename `revcomp{,ed}` to `reverse_complement{,ed}`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let codons = dna[4..].as_codons_mut();
 // Selects this: v-------------------------------------v
 //       ACAC    ACA TAT CTT ACG CTT AGG AAA TCT GAC CCG    AA
 
-codons[3..8].revcomp();
+codons[3..8].reverse_complement();
 // Reverse complements this: v-----------------v
 //       ACAC    ACA TAT CTT ACG CTT AGG AAA TCT GAC CCG    AA
 // Changing it to:           AGA TTT CCT AAG CGT
@@ -54,7 +54,7 @@ for _ in 0..4 {
 // Apply reverse compliment and NCBI1 non-destructively.
 let peptide: Peptide = dna
     .iter()
-    .revcomped()
+    .reverse_complemented()
     .translated_by(NCBI1)
     .collect();
 assert_eq!(peptide, "TRAVERSE*VIEW");

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,8 @@
 * `Seq` now has limited support for `ToOwned`, `Borrow` and `BorrowMut`. (#47)
 * `DnaSlice` and `DnaIter` were renamed to `DnaSliceExt` and `DnaIterExt` to reflect that
   they're extension traits. (#48, #49)
+* Rename `revcomp{,ed}` to `reverse_complement{,ed}`. The latter is annoying to type,
+  but easier to remember. (#51)
 
 ## Version 0.3.1 (2026-04-20)
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -15,10 +15,10 @@ pub trait DnaIterExt: Iterator {
     /// ```
     /// use nucs::{DnaIterExt, Nuc};
     ///
-    /// let complement = Nuc::arr(b"GATTACA").into_iter().revcomped();
+    /// let complement = Nuc::arr(b"GATTACA").into_iter().reverse_complemented();
     /// assert!(complement.eq(Nuc::arr(b"TGTAATC")));
     /// ```
-    fn revcomped<N>(self) -> Complemented<N, std::iter::Rev<Self>>
+    fn reverse_complemented<N>(self) -> Complemented<N, std::iter::Rev<Self>>
     where
         Self: Sized + DoubleEndedIterator<Item: AsRef<N>>,
         N: Nucleotide,
@@ -60,10 +60,10 @@ pub trait DnaIterExt: Iterator {
     /// use nucs::{DnaIterExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"GATTACA");
-    /// dna.iter_mut().revcomp();
+    /// dna.iter_mut().reverse_complement();
     /// assert_eq!(dna, Nuc::arr(b"TGTAATC"));
     /// ```
-    fn revcomp<N>(mut self)
+    fn reverse_complement<N>(mut self)
     where
         Self: Sized + DoubleEndedIterator<Item: AsMut<N>>,
         N: Nucleotide,
@@ -546,7 +546,7 @@ mod tests {
     }
 
     #[test]
-    fn revcomp_type_inference() {
+    fn reverse_complement_type_inference() {
         fn anon_muts<'a>(
             iter: impl IntoIterator<IntoIter: DoubleEndedIterator, Item = &'a mut impl Nucleotide>,
         ) -> impl IntoIterator<IntoIter: DoubleEndedIterator, Item = &'a mut impl Nucleotide>
@@ -555,7 +555,7 @@ mod tests {
         }
 
         let mut dna = Nuc::arr(b"AAAACCCGGT");
-        anon_muts(&mut dna).into_iter().revcomp();
+        anon_muts(&mut dna).into_iter().reverse_complement();
         assert_eq!(dna, Nuc::arr(b"ACCGGGTTTT"));
     }
 
@@ -648,29 +648,29 @@ mod tests {
     }
 
     #[test]
-    fn revcomp() {
+    fn reverse_complement() {
         let mut dna = Nuc::arr(b"");
-        dna.iter_mut().revcomp(); // just sanity check a lack of panics
+        dna.iter_mut().reverse_complement(); // just sanity check a lack of panics
 
         let mut dna = Nuc::arr(b"A");
-        dna.iter_mut().revcomp();
+        dna.iter_mut().reverse_complement();
         assert_eq!(dna, Nuc::arr(b"T"));
 
         let mut dna = Nuc::arr(b"AC");
-        dna.iter_mut().revcomp();
+        dna.iter_mut().reverse_complement();
         assert_eq!(dna, Nuc::arr(b"GT"));
 
         let mut dna = Nuc::arr(b"ACT");
-        dna.iter_mut().revcomp();
+        dna.iter_mut().reverse_complement();
         assert_eq!(dna, Nuc::arr(b"AGT"));
 
         let mut dna = Nuc::arr(b"GACT");
-        dna.iter_mut().revcomp();
+        dna.iter_mut().reverse_complement();
         assert_eq!(dna, Nuc::arr(b"AGTC"));
     }
 
     #[test]
-    fn revcomp_calls_as_mut_once_per_nucleotide() {
+    fn reverse_complement_calls_as_mut_once_per_nucleotide() {
         struct SingleUseMut<'a>(Option<&'a mut Nuc>);
 
         impl AsMut<Nuc> for SingleUseMut<'_> {
@@ -685,28 +685,28 @@ mod tests {
             .map(Some)
             .map(SingleUseMut)
             .into_iter()
-            .revcomp();
+            .reverse_complement();
     }
 
     proptest! {
         #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
         #[test]
-        fn revcomp_is_involution(dna in any_dna(0..50)) {
-            let mut dna2: Vec<_> = dna.iter().revcomped().revcomped().collect();
+        fn reverse_complement_is_involution(dna in any_dna(0..50)) {
+            let mut dna2: Vec<_> = dna.iter().reverse_complemented().reverse_complemented().collect();
             assert_eq!(dna, dna2);
-            dna2.iter_mut().revcomp();
-            dna2.iter_mut().revcomp();
+            dna2.iter_mut().reverse_complement();
+            dna2.iter_mut().reverse_complement();
             assert_eq!(dna, dna2);
         }
 
         #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
         #[test]
-        fn revcomp_matches_reverse_and_complement(mut dna in any_dna(0..50)) {
-            // Iterator revcomp isn't trivial, so compare against something that is
+        fn reverse_complement_matches_reverse_and_complement(mut dna in any_dna(0..50)) {
+            // Iterator reverse_complement isn't trivial, so compare against something that is
             let mut expected = dna.clone();
             expected.reverse();
             expected.complement();
-            dna.iter_mut().revcomp();
+            dna.iter_mut().reverse_complement();
             assert_eq!(dna, expected);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!         &[[A, T, T]],
 //!     ] as [&[_]; _]
 //! );
-//! slice.revcomp(); // in-place reverse-complement
+//! slice.reverse_complement(); // in-place reverse-complement
 //! assert_eq!(dna, "CTAATGT");
 //!
 //! // `DnaIterExt` supplies helpers for working with DNA iterators non-destructively:
@@ -60,7 +60,7 @@
 //! let iter = dna
 //!     .iter()
 //!     .trimmed_to_codon()
-//!     .revcomped();
+//!     .reverse_complemented();
 //! // (cloneable) DNA iterators can be displayed too:
 //! let wrapped = format!("{:#3}", iter.display());
 //! assert_eq!(wrapped, "CAT\nTAG");

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -508,11 +508,11 @@ pub trait DnaSliceExt {
     /// use nucs::{DnaSliceExt, Nuc};
     ///
     /// let mut dna = Nuc::arr(b"CATATTAC");
-    /// dna.revcomp();
+    /// dna.reverse_complement();
     /// assert_eq!(dna, Nuc::arr(b"GTAATATG"));
     /// ```
-    fn revcomp(&mut self) {
-        self.as_flat_dna_mut().iter_mut().revcomp();
+    fn reverse_complement(&mut self) {
+        self.as_flat_dna_mut().iter_mut().reverse_complement();
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -693,7 +693,7 @@ mod tests {
                 for n3 in Nuc::ALL {
                     let codon = [n1, n2, n3];
                     let mut codon_rc = codon;
-                    codon_rc.revcomp();
+                    codon_rc.reverse_complement();
                     assert_eq!(
                         NCBI1.translate_rc(codon),
                         NCBI1.translate(codon_rc),
@@ -711,7 +711,7 @@ mod tests {
                 for n3 in AmbiNuc::ALL {
                     let codon = [n1, n2, n3];
                     let mut codon_rc = codon;
-                    codon_rc.revcomp();
+                    codon_rc.reverse_complement();
                     assert_eq!(
                         NCBI1.translate_rc(codon),
                         NCBI1.translate(codon_rc),


### PR DESCRIPTION
The latter is admittedly long and annoying to type, but easier to remember.