### PR TITLE
Allow comparing symbols with strings.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 * Rename `revcomp{,ed}` to `reverse_complement{,ed}`. The latter is annoying to type,
   but easier to remember. (#51)
 * Rework translation to use more of a builder pattern. (#52, #53, #54)
+* Allow comparison between `Symbol`s and strings. (#57)
 
 ## Version 0.3.1 (2026-04-20)
 

--- a/src/amino.rs
+++ b/src/amino.rs
@@ -250,6 +250,18 @@ impl FromStr for Amino {
     }
 }
 
+impl PartialEq<&str> for Amino {
+    fn eq(&self, s: &&str) -> bool {
+        self == *s
+    }
+}
+
+impl PartialEq<str> for Amino {
+    fn eq(&self, s: &str) -> bool {
+        Seq([*self]) == s
+    }
+}
+
 impl AsRef<Amino> for Amino {
     fn as_ref(&self) -> &Amino {
         self
@@ -719,6 +731,18 @@ impl PartialOrd<Amino> for AmbiAmino {
 impl PartialOrd<AmbiAmino> for Amino {
     fn partial_cmp(&self, other: &AmbiAmino) -> Option<Ordering> {
         other.partial_cmp(self).map(Ordering::reverse)
+    }
+}
+
+impl PartialEq<&str> for AmbiAmino {
+    fn eq(&self, s: &&str) -> bool {
+        self == *s
+    }
+}
+
+impl PartialEq<str> for AmbiAmino {
+    fn eq(&self, s: &str) -> bool {
+        Seq([*self]) == s
     }
 }
 

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -200,6 +200,18 @@ impl TryFrom<AmbiNuc> for Nuc {
     }
 }
 
+impl PartialEq<&str> for Nuc {
+    fn eq(&self, s: &&str) -> bool {
+        self == *s
+    }
+}
+
+impl PartialEq<str> for Nuc {
+    fn eq(&self, s: &str) -> bool {
+        Seq([*self]) == s
+    }
+}
+
 impl AsRef<Nuc> for Nuc {
     fn as_ref(&self) -> &Nuc {
         self
@@ -635,6 +647,18 @@ impl PartialOrd<Nuc> for AmbiNuc {
 impl PartialOrd<AmbiNuc> for Nuc {
     fn partial_cmp(&self, other: &AmbiNuc) -> Option<Ordering> {
         other.partial_cmp(self).map(Ordering::reverse)
+    }
+}
+
+impl PartialEq<&str> for AmbiNuc {
+    fn eq(&self, s: &&str) -> bool {
+        self == *s
+    }
+}
+
+impl PartialEq<str> for AmbiNuc {
+    fn eq(&self, s: &str) -> bool {
+        Seq([*self]) == s
     }
 }
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -25,6 +25,7 @@ pub trait Symbol:
     + PartialOrd<Self::Concrete>
     + PartialEq<Self::Ambiguous>
     + PartialOrd<Self::Ambiguous>
+    + PartialEq<str>
     + Into<Self::Ambiguous>
     + TryInto<Self::Concrete>
     + Hash


### PR DESCRIPTION
This is so that `assert_eq!(dna[i], "G");` works.