### PR TITLE
Reading frames improvements

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
   but easier to remember. (#51)
 * Rework translation to use more of a builder pattern. (#52, #53, #54)
 * Allow comparison between `Symbol`s and strings. (#57)
+* Make `DnaSliceExt::reading_frames` return flat DNA and add `Seq::reading_frames`. (#58)
 
 ## Version 0.3.1 (2026-04-20)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,13 @@
 //! // (whether or not they're wrapped in `Seq`)
 //! use nucs::DnaSliceExt;
 //! use Nuc::{A, C, G, T};
+//! let slice = dna.make_contiguous();
 //! assert_eq!(
 //!     slice.reading_frames(),
 //!     [
-//!         &[[A, C, A], [T, T, A]],
-//!         &[[C, A, T], [T, A ,G]],
-//!         &[[A, T, T]],
+//!         &[A, C, A, T, T, A],
+//!         &[C, A, T, T, A ,G],
+//!         &[A, T, T],
 //!     ] as [&[_]; _]
 //! );
 //! slice.reverse_complement(); // in-place reverse-complement

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -117,6 +117,32 @@ impl<T: ?Sized> Seq<T> {
     #[ref_cast_custom]
     pub fn wrap_mut(slice: &mut T) -> &mut Self;
 
+    /// Return all 3 reading frames.
+    ///
+    /// The `i`th reading frame is a slice starting at `i` that's as long as possible while
+    /// being evenly divisible into codons (i.e. its length is a multiple of 3).
+    ///
+    /// If a reading frame would start past the end of the DNA, it's empty.
+    ///
+    /// This is like [`DnaSliceExt::reading_frames`] except the reading frames are wrapped
+    /// in [`Seq`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::Nuc;
+    ///
+    /// let dna = Nuc::seq(b"ACATATTAC");
+    /// assert_eq!(dna.reading_frames(), ["ACA TAT TAC", "CAT ATT", "ATA TTA"]);
+    /// ```
+    pub fn reading_frames<'a, S: 'a>(&'a self) -> [&'a Seq<[<[S] as DnaSliceExt>::Nuc]>; 3]
+    where
+        T: AsRef<[S]>,
+        [S]: DnaSliceExt,
+    {
+        self.0.as_ref().reading_frames().map(Seq::wrap)
+    }
+
     /// Return translation of DNA via [`GeneticCode`].
     ///
     /// This returns a builder for performing translations. See [`Translation`] for details.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -173,10 +173,12 @@ pub trait DnaSliceExt {
         Seq::wrap_mut(self)
     }
 
-    /// Return all 3 reading frames of codons
+    /// Return all 3 reading frames
     ///
-    /// Akin to non-panicking version of:
-    /// `[dna[0..].as_codons(), dna[1..].as_codons(), dna[2..].as_codons()]`
+    /// The `i`th reading frame is a slice starting at `i` that's as long as possible while
+    /// being evenly divisible into codons (i.e. its length is a multiple of 3).
+    ///
+    /// If a reading frame would start past the end of the DNA, it's empty.
     ///
     /// # Examples
     ///
@@ -188,14 +190,20 @@ pub trait DnaSliceExt {
     /// assert_eq!(
     ///     dna.reading_frames(),
     ///     [
-    ///         &[[A, C, A], [T, A, T], [T, A, C]] as &[_],
-    ///         &[[C, A, T], [A, T, T]],
-    ///         &[[A, T, A], [T, T, A]],
+    ///         &[A, C, A, T, A, T, T, A, C] as &[_],
+    ///         &[C, A, T, A, T, T],
+    ///         &[A, T, A, T, T, A],
     ///     ]
     /// );
     /// ```
-    fn reading_frames(&self) -> [&[[Self::Nuc; 3]]; 3] {
-        std::array::from_fn(|i| self.as_flat_dna().get(i..).unwrap_or_default().as_codons())
+    fn reading_frames(&self) -> [&[Self::Nuc]; 3] {
+        std::array::from_fn(|i| {
+            self.as_flat_dna()
+                .get(i..)
+                .unwrap_or_default()
+                .as_codons()
+                .as_flat_dna()
+        })
     }
 
     /// Return translation of DNA via [`GeneticCode`].


### PR DESCRIPTION
Makes reading frames return flat DNA instead of codons; mainly because right now `nucs` codon support isn't as nice as flat DNA support, so testing and example snippets are a little easier. If the original behavior is desirable, `DnaSliceExt::as_codons` can be used.

Also adds `Seq::reading_frames`, which is mostly the same, except it wraps the returned reading frames in `Seq`.