### PR TITLE
Add `complement` and `reverse_complement` to `Seq`.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+* `Seq` now has `complement` and `reverse_complement` methods. (#61)
+
 ## Version 0.4.0 (2026-07-28)
 
 * `Seq` now wraps subslices so e.g. `assert_eq!(&dna[2..], "ATCG");` now works. (#46)

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -202,6 +202,44 @@ impl<T: ?Sized> Seq<T> {
     {
         self.0.into_iter().translated_by(genetic_code)
     }
+
+    /// Perform in-place complement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::Nuc;
+    ///
+    /// let mut dna = Nuc::seq(b"CATATTAC");
+    /// dna.complement();
+    /// assert_eq!(dna, "GTATAATG");
+    /// ```
+    pub fn complement<S>(&mut self)
+    where
+        T: AsMut<[S]>,
+        [S]: DnaSliceExt,
+    {
+        self.0.as_mut().complement();
+    }
+
+    /// Perform in-place reverse-complement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nucs::Nuc;
+    ///
+    /// let mut dna = Nuc::seq(b"CATATTAC");
+    /// dna.reverse_complement();
+    /// assert_eq!(dna, "GTAATATG");
+    /// ```
+    pub fn reverse_complement<S>(&mut self)
+    where
+        T: AsMut<[S]>,
+        [S]: DnaSliceExt,
+    {
+        self.0.as_mut().reverse_complement();
+    }
 }
 
 impl<T: ?Sized> Deref for Seq<T> {


### PR DESCRIPTION
This is one more step towards not needing `DnaSliceExt` when working with `Seq` for common types.