### PR TITLE
Add minimal packed types.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * `Seq` now has `complement` and `reverse_complement` methods. (#61)
+* Add basic support for packed types! (#62)
 
 ## Version 0.4.0 (2026-07-28)
 

--- a/src/amino.rs
+++ b/src/amino.rs
@@ -231,6 +231,42 @@ impl Amino {
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Amino; N]> {
         Seq(Self::arr(literal))
     }
+
+    /// Compress to value in `1..=23`.
+    pub(crate) fn compress(self) -> u16 {
+        match self {
+            Amino::Stop => 1,
+            Amino::A => 2,
+            Amino::C => 3,
+            Amino::D => 4,
+            Amino::E => 5,
+            Amino::F => 6,
+            Amino::G => 7,
+            Amino::H => 8,
+            Amino::I => 9,
+            Amino::K => 10,
+            Amino::L => 11,
+            Amino::M => 12,
+            Amino::N => 13,
+            Amino::O => 14,
+            Amino::P => 15,
+            Amino::Q => 16,
+            Amino::R => 17,
+            Amino::S => 18,
+            Amino::T => 19,
+            Amino::U => 20,
+            Amino::V => 21,
+            Amino::W => 22,
+            Amino::Y => 23,
+        }
+    }
+
+    /// Opposite of `compress`; ignores anything beyond the 5 least-significant bits.
+    pub(crate) fn decompress(compressed: u16) -> Self {
+        // So close to Amino::ALL :/ But trying to avoid the -1...
+        const AMINOS: [Amino; 24] = Amino::arr(b"**ACDEFGHIKLMNOPQRSTUVWY");
+        AMINOS[(compressed & 0b11111) as usize]
+    }
 }
 
 impl Display for Amino {
@@ -613,6 +649,26 @@ impl AmbiAmino {
 
     pub(crate) const fn bit_mask(amino: Amino) -> u32 {
         1 << Self::bit_offset(amino)
+    }
+
+    // The bit layout of all valid AmbiAminos:
+    // 000000x0 xxxxxxxx xxxxxxxx xxxxx0x1
+    //          <--------21 bits------>
+    // These two functions try to keep the order of the bits the same so that the
+    // resulting [u8; 3] is ordered the same as AmbiAmino.
+
+    pub(crate) fn compress(self) -> [u8; 3] {
+        let bits = self.0.get();
+        let bits = ((bits & 0x2) >> 1) | ((bits & 0x00FF_FFF8) >> 2) | ((bits & 0x0200_0000) >> 3);
+        let [_, b2, b3, b4] = bits.to_be_bytes();
+        [b2, b3, b4]
+    }
+
+    pub(crate) fn decompress(compressed: [u8; 3]) -> Self {
+        let [b2, b3, b4] = compressed;
+        let bits = u32::from_be_bytes([0, b2, b3, b4]);
+        let bits = ((bits << 1) & 0x2) | ((bits << 2) & 0x00FF_FFF8) | ((bits << 3) & 0x0200_0000);
+        Self(NonZeroU32::MIN | bits)
     }
 }
 
@@ -1090,5 +1146,20 @@ mod tests {
         concrete_ambi_aminos.sort();
         expected.sort();
         assert_eq!(concrete_ambi_aminos, expected);
+    }
+
+    #[test]
+    fn amino_compression_roundtrips() {
+        for aa in Amino::ALL {
+            assert_eq!(Amino::decompress(aa.compress()), aa);
+        }
+    }
+
+    #[cfg_attr(debug_assertions, ignore = "slow outside of release mode")]
+    #[test]
+    fn ambi_amino_compression_roundtrips() {
+        for aa in all_ambi_aminos() {
+            assert_eq!(AmbiAmino::decompress(aa.compress()), aa);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ mod symbol;
 pub mod casts;
 pub mod error;
 pub mod iter;
+pub mod packed;
 #[cfg(any(feature = "proptest", test))]
 #[cfg_attr(docsrs, doc(cfg(feature = "proptest")))]
 pub mod proptest;
@@ -148,6 +149,7 @@ pub mod translation;
 pub use amino::{AmbiAmino, Amino};
 pub use iter::DnaIterExt;
 pub use nuc::{AmbiNuc, Nuc, Nucleotide};
+pub use packed::Packed;
 pub use seq::Seq;
 pub use slice::DnaSliceExt;
 pub use symbol::Symbol;

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -167,6 +167,21 @@ impl Nuc {
     pub const fn seq<const N: usize>(literal: &[u8; N]) -> Seq<[Nuc; N]> {
         Seq(Self::arr(literal))
     }
+
+    /// Compress to value in range `0..=3`
+    pub(crate) fn compress(self) -> u8 {
+        match self {
+            Nuc::A => 0,
+            Nuc::C => 1,
+            Nuc::G => 2,
+            Nuc::T => 3,
+        }
+    }
+
+    /// Opposite of `compress`; ignores anything beyond the 2 least-significant bits.
+    pub(crate) fn decompress(compressed: u8) -> Self {
+        [Nuc::A, Nuc::C, Nuc::G, Nuc::T][(compressed & 0b11) as usize]
+    }
 }
 
 impl Display for Nuc {
@@ -534,6 +549,16 @@ impl AmbiNuc {
             }};
         }
         from_u8!(byte, A C M G R S V T W Y H K D B N)
+    }
+
+    /// Compress to value in `1..=15`.
+    pub(crate) fn compress(self) -> u8 {
+        self as _
+    }
+
+    /// Opposite of `compress`; ignores anything beyond the 4 least-significant bits.
+    pub(crate) fn decompress(compressed: u8) -> Self {
+        Self::from_u8(compressed & 0b1111).unwrap()
     }
 }
 
@@ -992,5 +1017,19 @@ mod tests {
         let mut sorted = AmbiNuc::ALL;
         sorted.sort();
         assert_eq!(AmbiNuc::ALL, sorted);
+    }
+
+    #[test]
+    fn nuc_compression_roundtrips() {
+        for nuc in Nuc::ALL {
+            assert_eq!(Nuc::decompress(nuc.compress()), nuc);
+        }
+    }
+
+    #[test]
+    fn ambi_nuc_compression_roundtrips() {
+        for nuc in AmbiNuc::ALL {
+            assert_eq!(AmbiNuc::decompress(nuc.compress()), nuc);
+        }
     }
 }

--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -1,0 +1,201 @@
+use crate::AmbiNuc;
+
+use super::{ArrayDefault, ArrayDivide};
+
+// Note on storage: AmbiNucs are packed big-endian so naive lexical sorting of bytes is correct.
+//
+// The last byte of a non-empty `PackedAmbiDna` must have 1-2 elements. If it has 1 element,
+// the least-significant 4 bits are b0000, which isn't a valid representation.
+
+/// Like [`Vec<AmbiNuc>`], but takes 50% less space for long DNA sequences.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{AmbiNuc, Packed};
+///
+/// let dna = AmbiNuc::arr(b"ACATATTACK");
+/// let packed: Packed<[AmbiNuc]> = dna.as_slice().into();
+/// let unpacked: Vec<AmbiNuc> = packed.into();
+/// assert_eq!(unpacked, dna);
+/// ```
+#[derive(Clone)]
+pub struct PackedAmbiDna(Vec<u8>);
+
+impl From<&[AmbiNuc]> for PackedAmbiDna {
+    fn from(ambi_nucs: &[AmbiNuc]) -> PackedAmbiDna {
+        let packed_len = ambi_nucs.len().div_ceil(2);
+        let mut packed = vec![0; packed_len];
+        pack(&mut packed, ambi_nucs);
+        Self(packed)
+    }
+}
+
+impl From<PackedAmbiDna> for Vec<AmbiNuc> {
+    fn from(packed_ambi_nucs: PackedAmbiDna) -> Vec<AmbiNuc> {
+        (&packed_ambi_nucs).into()
+    }
+}
+
+impl From<&PackedAmbiDna> for Vec<AmbiNuc> {
+    fn from(packed_ambi_nucs: &PackedAmbiDna) -> Vec<AmbiNuc> {
+        if let Some(byte) = packed_ambi_nucs.0.last() {
+            let len = 2 * packed_ambi_nucs.0.len() - usize::from(byte.trailing_zeros() >= 4);
+            let mut ambi_nucs = vec![AmbiNuc::default(); len];
+            unpack(&mut ambi_nucs, &packed_ambi_nucs.0);
+            ambi_nucs
+        } else {
+            vec![]
+        }
+    }
+}
+
+/// Like [`[AmbiNuc; N]`](array), but takes 50% less space.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{AmbiNuc, Packed};
+///
+/// let dna = AmbiNuc::arr(b"ACATATTACK");
+/// assert_eq!(size_of_val(&dna), 10);
+/// let packed: Packed<[AmbiNuc; 10]> = dna.into();
+/// assert_eq!(size_of_val(&packed), 5);
+/// let unpacked: [AmbiNuc; 10] = packed.into();
+/// assert_eq!(unpacked, dna);
+/// ```
+#[derive(Clone, Copy)]
+pub struct PackedArrayAmbiDna<const N: usize>(<[(); N] as ArrayDivide>::By2<u8>)
+where
+    [(); N]: ArrayDivide;
+
+impl<const N: usize> From<[AmbiNuc; N]> for PackedArrayAmbiDna<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(ambi_nucs: [AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
+        (&ambi_nucs).into()
+    }
+}
+
+impl<const N: usize> From<&[AmbiNuc; N]> for PackedArrayAmbiDna<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(ambi_nucs: &[AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
+        let mut this = Self(ArrayDefault::array_default());
+        pack(this.0.as_mut(), ambi_nucs);
+        this
+    }
+}
+
+impl<const N: usize> From<PackedArrayAmbiDna<N>> for [AmbiNuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_ambi_nucs: PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
+        (&packed_ambi_nucs).into()
+    }
+}
+
+impl<const N: usize> From<&PackedArrayAmbiDna<N>> for [AmbiNuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_ambi_nucs: &PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
+        let mut ambi_nucs = [AmbiNuc::default(); N];
+        unpack(&mut ambi_nucs, packed_ambi_nucs.0.as_ref());
+        ambi_nucs
+    }
+}
+
+fn pack(packed: &mut [u8], ambi_nucs: &[AmbiNuc]) {
+    let (pairs, remainder) = ambi_nucs.as_chunks();
+    for (byte, &[n1, n2]) in packed.iter_mut().zip(pairs) {
+        *byte = n2.compress() | (n1.compress() << 4);
+    }
+    if let Some(byte) = packed.last_mut()
+        && let [ambi_nuc] = remainder
+    {
+        *byte = ambi_nuc.compress() << 4;
+    }
+}
+
+fn unpack(ambi_nucs: &mut [AmbiNuc], packed: &[u8]) {
+    let (pairs, remainder) = ambi_nucs.as_chunks_mut();
+    for ([n1, n2], &byte) in pairs.iter_mut().zip(packed) {
+        *n1 = AmbiNuc::decompress(byte >> 4);
+        *n2 = AmbiNuc::decompress(byte);
+    }
+    if let Some(byte) = packed.last()
+        && let [ambi_nuc] = remainder
+    {
+        *ambi_nuc = AmbiNuc::decompress(byte >> 4);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{arbitrary::any, proptest};
+
+    use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
+    use crate::proptest::any_ambi_dna;
+
+    use super::*;
+
+    #[test]
+    fn all_short_roundtrips() {
+        // Yes, this is hideously ugly, but arrays need a size known at compile-time,
+        // and this is the simplest way to ensure I get them all.
+        assert_both_roundtrips(&[] as &[AmbiNuc; 0]);
+        for n1 in AmbiNuc::ALL {
+            assert_both_roundtrips(&[n1]);
+            for n2 in AmbiNuc::ALL {
+                assert_both_roundtrips(&[n1, n2]);
+                for n3 in AmbiNuc::ALL {
+                    assert_both_roundtrips(&[n1, n2, n3]);
+                    for n4 in AmbiNuc::ALL {
+                        assert_both_roundtrips(&[n1, n2, n3, n4]);
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_dna_roundtrip(
+            ambi_dna in any_ambi_dna(5..25) // 0..=4 covered above
+        ) {
+            assert_roundtrip(&*ambi_dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_ambi_dna5_roundtrip(
+            ambi_dna in any::<[AmbiNuc; 5]>()
+        ) {
+            assert_roundtrip(&ambi_dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_ambi_dna6_roundtrip(
+            ambi_dna in any::<[AmbiNuc; 6]>()
+        ) {
+            assert_roundtrip(&ambi_dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_dna_lexical_ordering(
+            dna1 in any_ambi_dna(0..50),
+            dna2 in any_ambi_dna(0..50),
+        ) {
+            let packed1 = PackedAmbiDna::from(dna1.as_slice());
+            let packed2 = PackedAmbiDna::from(dna2.as_slice());
+            assert_eq!(packed1.0.cmp(&packed2.0), dna1.cmp(&dna2));
+        }
+    }
+}

--- a/src/packed/ambipeptide.rs
+++ b/src/packed/ambipeptide.rs
@@ -1,0 +1,120 @@
+use crate::AmbiAmino;
+
+// Note on storage: There's not much room for packing `AmbiAmino`s... we can shave off one byte,
+// but that's about it. Again, we store thing big-endian for lexical sorting reasons.
+// The good news is that this means a lot of the logic is pretty simple.
+
+/// Like [`Vec<AmbiAmino>`], but takes 25% less space for long peptides.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{AmbiAmino, Packed};
+///
+/// let peptide = AmbiAmino::arr(b"KITTYJUMPSOFDANGER");
+/// let packed: Packed<[AmbiAmino]> = peptide.as_slice().into();
+/// let unpacked: Vec<AmbiAmino> = packed.into();
+/// assert_eq!(unpacked, peptide);
+/// ```
+#[derive(Clone)]
+pub struct PackedAmbiPeptide(Vec<[u8; 3]>);
+
+impl From<&[AmbiAmino]> for PackedAmbiPeptide {
+    fn from(ambi_aminos: &[AmbiAmino]) -> PackedAmbiPeptide {
+        Self(ambi_aminos.iter().map(|a| a.compress()).collect())
+    }
+}
+
+impl From<PackedAmbiPeptide> for Vec<AmbiAmino> {
+    fn from(packed_ambi_aminos: PackedAmbiPeptide) -> Vec<AmbiAmino> {
+        (&packed_ambi_aminos).into()
+    }
+}
+
+impl From<&PackedAmbiPeptide> for Vec<AmbiAmino> {
+    fn from(packed_ambi_aminos: &PackedAmbiPeptide) -> Vec<AmbiAmino> {
+        let packed = packed_ambi_aminos.0.iter();
+        packed.map(|&bits| AmbiAmino::decompress(bits)).collect()
+    }
+}
+
+/// Like [`[AmbiAmino; N]`](array), but takes 25% less space.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{AmbiAmino, Packed};
+///
+/// let peptide = AmbiAmino::arr(b"KITTYJUMPSOFDANGER");
+/// assert_eq!(size_of_val(&peptide), 72);
+/// let packed: Packed<[AmbiAmino; 18]> = peptide.into();
+/// assert_eq!(size_of_val(&packed), 54);
+/// let unpacked: [AmbiAmino; 18] = packed.into();
+/// assert_eq!(unpacked, peptide);
+/// ```
+#[derive(Clone, Copy)]
+pub struct PackedArrayAmbiPeptide<const N: usize>([[u8; 3]; N]);
+
+impl<const N: usize> From<[AmbiAmino; N]> for PackedArrayAmbiPeptide<N> {
+    fn from(ambi_aminos: [AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
+        (&ambi_aminos).into()
+    }
+}
+
+impl<const N: usize> From<&[AmbiAmino; N]> for PackedArrayAmbiPeptide<N> {
+    fn from(ambi_aminos: &[AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
+        Self(ambi_aminos.map(AmbiAmino::compress))
+    }
+}
+
+impl<const N: usize> From<PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
+    fn from(packed_ambi_aminos: PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
+        (&packed_ambi_aminos).into()
+    }
+}
+
+impl<const N: usize> From<&PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
+    fn from(packed_ambi_aminos: &PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
+        packed_ambi_aminos.0.map(AmbiAmino::decompress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::proptest;
+
+    use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
+    use crate::proptest::any_ambi_peptide;
+
+    use super::*;
+
+    #[test]
+    fn sanity_check_array_roundtrips() {
+        assert_both_roundtrips(&[] as &[AmbiAmino; 0]);
+        assert_both_roundtrips(&[AmbiAmino::A]);
+        assert_both_roundtrips(&[AmbiAmino::B, AmbiAmino::C]);
+        assert_both_roundtrips(&[AmbiAmino::D, AmbiAmino::E, AmbiAmino::F]);
+        assert_both_roundtrips(&AmbiAmino::arr(b"*SIGN"));
+    }
+
+    proptest! {
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_peptide_roundtrip(
+            ambi_peptide in any_ambi_peptide(1..25) // 0 covered above
+        ) {
+            assert_roundtrip(&*ambi_peptide);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_peptide_lexical_ordering(
+            peptide1 in any_ambi_peptide(0..50),
+            peptide2 in any_ambi_peptide(0..50),
+        ) {
+            let packed1 = PackedAmbiPeptide::from(peptide1.as_slice());
+            let packed2 = PackedAmbiPeptide::from(peptide2.as_slice());
+            assert_eq!(packed1.0.cmp(&packed2.0), peptide1.cmp(&peptide2));
+        }
+    }
+}

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -1,0 +1,238 @@
+use crate::Nuc;
+
+use super::{ArrayDefault, ArrayDivide};
+
+// Note on storage: Nucs are packed big-endian. Sadly, this encoding DOES NOT maintain lexical
+// ordering, due to the suffix (see below).
+//
+// The last byte of a non-empty `PackedDna` must have 0-3 elements. Any missing element is encoded
+// 0b00, and the the least significant 2 bits record the number of elements.
+//
+// We do this rather than store the length externally, both to minimize the memory usage
+// (with inline lengths, you don't need any extra memory 75% of the time, whereas with an
+// external u8, the Vec overhead would increase from 24 to 32 bytes) and to ensure the
+// length can be correctly inferred from serialized data.
+
+/// Like [`Vec<Nuc>`], but takes 75% less space for long DNA sequences.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{Nuc, Packed};
+///
+/// let dna = Nuc::arr(b"ACATATTAC");
+/// let packed: Packed<[Nuc]> = dna.as_slice().into();
+/// let unpacked: Vec<Nuc> = packed.into();
+/// assert_eq!(unpacked, dna);
+/// ```
+#[derive(Clone)]
+pub struct PackedDna(Vec<u8>);
+
+impl From<&[Nuc]> for PackedDna {
+    fn from(nucs: &[Nuc]) -> PackedDna {
+        let packed_len = match nucs.len() {
+            0 => 0, // special-case to reduce allocs
+            l => l / 4 + 1,
+        };
+        let mut packed = vec![0; packed_len];
+        pack(&mut packed, nucs);
+        if let Some(byte) = packed.last_mut() {
+            *byte |=
+                u8::try_from(nucs.len() % 4).unwrap_or_else(|_| unreachable!("x % 4 fits in a u8"));
+        }
+        Self(packed)
+    }
+}
+
+impl From<PackedDna> for Vec<Nuc> {
+    fn from(packed_nucs: PackedDna) -> Vec<Nuc> {
+        (&packed_nucs).into()
+    }
+}
+
+impl From<&PackedDna> for Vec<Nuc> {
+    fn from(packed_nucs: &PackedDna) -> Vec<Nuc> {
+        if let Some(byte) = packed_nucs.0.last() {
+            let len = 4 * (packed_nucs.0.len() - 1) + (byte & 0b11) as usize;
+            let mut nucs = vec![Nuc::default(); len];
+            unpack(&mut nucs, &packed_nucs.0);
+            nucs
+        } else {
+            vec![]
+        }
+    }
+}
+
+/// Like [`[Nuc; N]`](array), but takes 75% less space.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{Nuc, Packed};
+///
+/// let dna = Nuc::arr(b"ACATATTAC");
+/// assert_eq!(size_of_val(&dna), 9);
+/// let packed: Packed<[Nuc; 9]> = dna.into();
+/// assert_eq!(size_of_val(&packed), 3);
+/// let unpacked: [Nuc; 9] = packed.into();
+/// assert_eq!(unpacked, dna);
+/// ```
+#[derive(Clone, Copy)]
+pub struct PackedArrayDna<const N: usize>(<[(); N] as ArrayDivide>::By4<u8>)
+where
+    [(); N]: ArrayDivide;
+
+impl<const N: usize> From<[Nuc; N]> for PackedArrayDna<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(nucs: [Nuc; N]) -> PackedArrayDna<N> {
+        (&nucs).into()
+    }
+}
+
+impl<const N: usize> From<&[Nuc; N]> for PackedArrayDna<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(nucs: &[Nuc; N]) -> PackedArrayDna<N> {
+        let mut this = Self(ArrayDefault::array_default());
+        pack(this.0.as_mut(), nucs);
+        this
+    }
+}
+
+impl<const N: usize> From<PackedArrayDna<N>> for [Nuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_nucs: PackedArrayDna<N>) -> [Nuc; N] {
+        (&packed_nucs).into()
+    }
+}
+
+impl<const N: usize> From<&PackedArrayDna<N>> for [Nuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_nucs: &PackedArrayDna<N>) -> [Nuc; N] {
+        let mut nucs = [Nuc::default(); N];
+        unpack(&mut nucs, packed_nucs.0.as_ref());
+        nucs
+    }
+}
+
+fn pack(packed: &mut [u8], nucs: &[Nuc]) {
+    let (quads, remainder) = nucs.as_chunks();
+    for (byte, &[n1, n2, n3, n4]) in packed.iter_mut().zip(quads) {
+        *byte = n4.compress() | (n3.compress() << 2) | (n2.compress() << 4) | (n1.compress() << 6);
+    }
+    if let Some(byte) = packed.last_mut()
+        && !remainder.is_empty()
+    {
+        *byte = 0;
+        for (offset, &nuc) in [6, 4, 2].into_iter().zip(remainder) {
+            *byte |= nuc.compress() << offset;
+        }
+    }
+}
+
+fn unpack(nucs: &mut [Nuc], packed: &[u8]) {
+    let (quads, remainder) = nucs.as_chunks_mut();
+    for ([n1, n2, n3, n4], &byte) in quads.iter_mut().zip(packed) {
+        *n4 = Nuc::decompress(byte);
+        *n3 = Nuc::decompress(byte >> 2);
+        *n2 = Nuc::decompress(byte >> 4);
+        *n1 = Nuc::decompress(byte >> 6);
+    }
+    if let Some(byte) = packed.last()
+        && !remainder.is_empty()
+    {
+        for (offset, nuc) in [6, 4, 2].into_iter().zip(remainder) {
+            *nuc = Nuc::decompress(byte >> offset);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{arbitrary::any, proptest};
+
+    use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
+    use crate::proptest::any_dna;
+
+    use super::*;
+
+    #[test]
+    fn all_short_roundtrips() {
+        // Yes, this is hideously ugly, but arrays need a size known at compile-time,
+        // and this is the simplest way to ensure I get them all.
+        assert_both_roundtrips(&[] as &[Nuc; 0]);
+        for n1 in Nuc::ALL {
+            assert_both_roundtrips(&[n1]);
+            for n2 in Nuc::ALL {
+                assert_both_roundtrips(&[n1, n2]);
+                for n3 in Nuc::ALL {
+                    assert_both_roundtrips(&[n1, n2, n3]);
+                    for n4 in Nuc::ALL {
+                        assert_both_roundtrips(&[n1, n2, n3, n4]);
+                        for n5 in Nuc::ALL {
+                            assert_both_roundtrips(&[n1, n2, n3, n4, n5]);
+                            for n6 in Nuc::ALL {
+                                assert_both_roundtrips(&[n1, n2, n3, n4, n5, n6]);
+                                for n7 in Nuc::ALL {
+                                    assert_both_roundtrips(&[n1, n2, n3, n4, n5, n6, n7]);
+                                    for n8 in Nuc::ALL {
+                                        assert_both_roundtrips(&[n1, n2, n3, n4, n5, n6, n7, n8]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_dna_roundtrip(
+            dna in any_dna(9..50) // 0..=8 covered above
+        ) {
+            assert_roundtrip(&*dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna9_roundtrip(
+            dna in any::<[Nuc; 9]>()
+        ) {
+            assert_roundtrip(&dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna10_roundtrip(
+            dna in any::<[Nuc; 10]>()
+        ) {
+            assert_roundtrip(&dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna11_roundtrip(
+            dna in any::<[Nuc; 11]>()
+        ) {
+            assert_roundtrip(&dna);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna12_roundtrip(
+            dna in any::<[Nuc; 12]>()
+        ) {
+            assert_roundtrip(&dna);
+        }
+    }
+}

--- a/src/packed/mod.rs
+++ b/src/packed/mod.rs
@@ -1,0 +1,225 @@
+//! Packed sequence types
+
+use crate::{AmbiAmino, AmbiNuc, Amino, Nuc};
+
+mod ambidna;
+mod ambipeptide;
+mod dna;
+mod peptide;
+
+pub use ambidna::{PackedAmbiDna, PackedArrayAmbiDna};
+pub use ambipeptide::{PackedAmbiPeptide, PackedArrayAmbiPeptide};
+pub use dna::{PackedArrayDna, PackedDna};
+pub use peptide::{PackedArrayPeptide, PackedPeptide};
+
+/// Names packed types in terms of what data they're packing.
+///
+/// * [`Packed<[Nuc]>`](Self) is [`PackedDna`]
+/// * [`Packed<[Nuc; N]>`](Self) is [`PackedArrayDna<N>`]
+/// * [`Packed<[AmbiNuc]>`](Self) is [`PackedAmbiDna`]
+/// * [`Packed<[AmbiNuc; N]>`](Self) is [`PackedArrayAmbiDna<N>`]
+/// * [`Packed<[Amino]>`](Self) is [`PackedPeptide`]
+/// * [`Packed<[Amino; N]>`](Self) is [`PackedArrayPeptide<N>`]
+/// * [`Packed<[AmbiAmino]>`](Self) is [`PackedAmbiPeptide`]
+/// * [`Packed<[AmbiAmino; N]>`](Self) is [`PackedArrayAmbiPeptide<N>`]
+pub type Packed<T> = <T as Packable>::Packed;
+
+/// Determine packed version of type.
+///
+/// This should work for all `[impl Symbol]`, and sufficiently short `[impl Symbol; N]`
+/// (currently, `N <= 64`).
+pub trait Packable: ToOwned {
+    /// Packed version of [`Self`].
+    type Packed: Into<Self::Owned> + for<'a> From<&'a Self>;
+}
+
+impl Packable for [Nuc] {
+    type Packed = PackedDna;
+}
+
+impl<const N: usize> Packable for [Nuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    type Packed = PackedArrayDna<N>;
+}
+
+impl Packable for [AmbiNuc] {
+    type Packed = PackedAmbiDna;
+}
+
+impl<const N: usize> Packable for [AmbiNuc; N]
+where
+    [(); N]: ArrayDivide,
+{
+    type Packed = PackedArrayAmbiDna<N>;
+}
+
+impl Packable for [Amino] {
+    type Packed = PackedPeptide;
+}
+
+impl<const N: usize> Packable for [Amino; N]
+where
+    [(); N]: ArrayDivide,
+{
+    type Packed = PackedArrayPeptide<N>;
+}
+
+impl Packable for [AmbiAmino] {
+    type Packed = PackedAmbiPeptide;
+}
+
+impl<const N: usize> Packable for [AmbiAmino; N] {
+    type Packed = PackedArrayAmbiPeptide<N>;
+}
+
+/// Utility trait used to work out packed array sizes at compile-time.
+///
+/// The API/details of this are intended for internal use and are therefore unstable.
+pub trait ArrayDivide {
+    // `ArrayDivide` uses GATs rather than constants to work around limitations in the current
+    // trait solver: A type/trait can't declare an array with a length obtained from a trait's
+    // associated constant.
+    //
+    // In theory, we could use non-generic associated types by setting them to something like
+    // `[(); N]` and matching a const generic parameter against them, but that ends up introducing
+    // additional generic parameters into types, and more implementation-specific trait constraints
+    // into everything else, so it'd make the public API horribly complicated.
+
+    /// `[T; (2 * self.len()).div_ceil(3)]`
+    type By3_2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+    /// `[T; self.len().div_ceil(2)]`
+    type By2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+    /// `[T; self.len().div_ceil(4)]`
+    type By4<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+}
+
+/// Workaround for `[T; N]: Default` being limited to `N <= 32`
+///
+/// This is intended more as an internal implementation detail.
+pub trait ArrayDefault {
+    /// [`[T; N]::default`](Default#impl-Default-for-[T;+32]), but extended to any `N`.
+    fn array_default() -> Self;
+}
+
+impl<T: Default, const N: usize> ArrayDefault for [T; N] {
+    fn array_default() -> Self {
+        std::array::from_fn(|_| T::default())
+    }
+}
+
+macro_rules! div_table {
+    ( $( $d:literal => $q3_2:literal $q2:literal $q4:literal),+ , ) => {
+        $(
+            impl ArrayDivide for [(); $d] {
+                type By3_2<T: Copy + Default> = [T; $q3_2];
+                type By2<T: Copy + Default> = [T; $q2];
+                type By4<T: Copy + Default> = [T; $q4];
+            }
+        )+
+    };
+}
+
+div_table!(
+    // x => x/1.5 x/2 x/4
+       0 =>     0   0   0,
+       1 =>     1   1   1,
+       2 =>     2   1   1,
+       3 =>     2   2   1,
+       4 =>     3   2   1,
+       5 =>     4   3   2,
+       6 =>     4   3   2,
+       7 =>     5   4   2,
+       8 =>     6   4   2,
+       9 =>     6   5   3,
+      10 =>     7   5   3,
+      11 =>     8   6   3,
+      12 =>     8   6   3,
+      13 =>     9   7   4,
+      14 =>    10   7   4,
+      15 =>    10   8   4,
+      16 =>    11   8   4,
+      17 =>    12   9   5,
+      18 =>    12   9   5,
+      19 =>    13  10   5,
+      20 =>    14  10   5,
+      21 =>    14  11   6,
+      22 =>    15  11   6,
+      23 =>    16  12   6,
+      24 =>    16  12   6,
+      25 =>    17  13   7,
+      26 =>    18  13   7,
+      27 =>    18  14   7,
+      28 =>    19  14   7,
+      29 =>    20  15   8,
+      30 =>    20  15   8,
+      31 =>    21  16   8,
+      32 =>    22  16   8,
+      33 =>    22  17   9,
+      34 =>    23  17   9,
+      35 =>    24  18   9,
+      36 =>    24  18   9,
+      37 =>    25  19  10,
+      38 =>    26  19  10,
+      39 =>    26  20  10,
+      40 =>    27  20  10,
+      41 =>    28  21  11,
+      42 =>    28  21  11,
+      43 =>    29  22  11,
+      44 =>    30  22  11,
+      45 =>    30  23  12,
+      46 =>    31  23  12,
+      47 =>    32  24  12,
+      48 =>    32  24  12,
+      49 =>    33  25  13,
+      50 =>    34  25  13,
+      51 =>    34  26  13,
+      52 =>    35  26  13,
+      53 =>    36  27  14,
+      54 =>    36  27  14,
+      55 =>    37  28  14,
+      56 =>    38  28  14,
+      57 =>    38  29  15,
+      58 =>    39  29  15,
+      59 =>    40  30  15,
+      60 =>    40  30  15,
+      61 =>    41  31  16,
+      62 =>    42  31  16,
+      63 =>    42  32  16,
+      64 =>    43  32  16,
+    // TODO: Maybe consider up to 256? Probably overkill though.
+);
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use super::*;
+
+    #[track_caller]
+    pub(crate) fn assert_both_roundtrips<T, const N: usize>(arr: &[T; N])
+    where
+        T: Debug + PartialEq,
+        [T]: Packable<Owned = Vec<T>>,
+        [T; N]: Packable<Owned = [T; N]>,
+    {
+        assert_roundtrip(arr.as_slice());
+        assert_roundtrip(arr);
+    }
+
+    #[track_caller]
+    pub(crate) fn assert_roundtrip<T>(packable: &T)
+    where
+        T: Packable + Debug + ?Sized,
+        T::Owned: Debug + PartialEq<T>,
+    {
+        let roundtripped: T::Owned = <T::Packed>::from(packable).into();
+        assert_eq!(
+            roundtripped,
+            *packable,
+            "roundtrip failed for {}",
+            std::any::type_name::<T>()
+        );
+    }
+}

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -1,0 +1,231 @@
+use crate::Amino;
+
+use super::{ArrayDefault, ArrayDivide};
+
+// Note on storage: Aminos are packed big-endian so naive lexical sorting of bytes is correct.
+// The [u8; 2] themselves are big-endian u16s, for the same reason.
+//
+// The last word of a non-empty `PackedPeptide` must have 1-3 elements. If it has 2 elements,
+// the 5 least-significant bits are 0. If it has 1 element, the 10 least-significant bits would
+// be 0, so only the upper byte is stored; this means the amino is at bits 2..7, not 0..5.
+
+// NOTE to future self: when implementing iterators, it'll make the most sense to cast to
+// &[[u8; 2]] then chain its iter to an Option<Amino>.
+
+/// Like [`Vec<Amino>`], but takes 33% less space for long peptides.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{Amino, Packed};
+///
+/// let peptide = Amino::arr(b"KITTYTUMSOFDANGER");
+/// let packed: Packed<[Amino]> = peptide.as_slice().into();
+/// let unpacked: Vec<Amino> = packed.into();
+/// assert_eq!(unpacked, peptide);
+/// ```
+#[derive(Clone)]
+pub struct PackedPeptide(Vec<u8>);
+
+impl From<&[Amino]> for PackedPeptide {
+    fn from(aminos: &[Amino]) -> PackedPeptide {
+        let packed_len = (2 * aminos.len()).div_ceil(3);
+        let mut packed = vec![0; packed_len];
+        pack(&mut packed, aminos);
+        Self(packed)
+    }
+}
+
+impl From<PackedPeptide> for Vec<Amino> {
+    fn from(packed_aminos: PackedPeptide) -> Vec<Amino> {
+        (&packed_aminos).into()
+    }
+}
+
+impl From<&PackedPeptide> for Vec<Amino> {
+    fn from(packed_aminos: &PackedPeptide) -> Vec<Amino> {
+        let len = match packed_aminos.0.as_chunks::<2>() {
+            (pairs, [_]) => 3 * pairs.len() + 1,
+            (pairs @ [.., last_pair], []) => {
+                3 * pairs.len() - (u16::from_be_bytes(*last_pair).trailing_zeros() / 5) as usize
+            }
+            _ => return vec![],
+        };
+        let mut aminos = vec![Amino::default(); len];
+        unpack(&mut aminos, &packed_aminos.0);
+        aminos
+    }
+}
+
+/// Like [`[Amino; N]`](array), but takes 33% less space.
+///
+/// # Examples
+///
+/// ```
+/// use nucs::{Amino, Packed};
+///
+/// let peptide = Amino::arr(b"KITTYTUMSOFDANGER");
+/// assert_eq!(size_of_val(&peptide), 17);
+/// let packed: Packed<[Amino; 17]> = peptide.into();
+/// assert_eq!(size_of_val(&packed), 12);
+/// let unpacked: [Amino; 17] = packed.into();
+/// assert_eq!(unpacked, peptide);
+/// ```
+#[derive(Clone, Copy)]
+pub struct PackedArrayPeptide<const N: usize>(<[(); N] as ArrayDivide>::By3_2<u8>)
+where
+    [(); N]: ArrayDivide;
+
+impl<const N: usize> From<[Amino; N]> for PackedArrayPeptide<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(aminos: [Amino; N]) -> PackedArrayPeptide<N> {
+        (&aminos).into()
+    }
+}
+
+impl<const N: usize> From<&[Amino; N]> for PackedArrayPeptide<N>
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(aminos: &[Amino; N]) -> PackedArrayPeptide<N> {
+        let mut this = Self(ArrayDefault::array_default());
+        pack(this.0.as_mut(), aminos);
+        this
+    }
+}
+
+impl<const N: usize> From<PackedArrayPeptide<N>> for [Amino; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_aminos: PackedArrayPeptide<N>) -> [Amino; N] {
+        (&packed_aminos).into()
+    }
+}
+
+impl<const N: usize> From<&PackedArrayPeptide<N>> for [Amino; N]
+where
+    [(); N]: ArrayDivide,
+{
+    fn from(packed_aminos: &PackedArrayPeptide<N>) -> [Amino; N] {
+        let mut aminos = [Amino::default(); N];
+        unpack(&mut aminos, packed_aminos.0.as_ref());
+        aminos
+    }
+}
+
+fn pack(packed: &mut [u8], aminos: &[Amino]) {
+    let (pairs, packed_remainder) = packed.as_chunks_mut();
+    let (triplets, amino_remainder) = aminos.as_chunks();
+    for (pair, &[a1, a2, a3]) in pairs.iter_mut().zip(triplets) {
+        *pair = (a3.compress() | (a2.compress() << 5) | (a1.compress() << 10)).to_be_bytes();
+    }
+    match (packed_remainder, amino_remainder) {
+        ([], []) => {}
+        ([b1], &[a1]) => [*b1, _] = (a1.compress() << 10).to_be_bytes(),
+        ([], &[a1, a2]) => {
+            *pairs.last_mut().unwrap() =
+                ((a2.compress() << 5) | (a1.compress() << 10)).to_be_bytes();
+        }
+        _ => panic!(),
+    }
+}
+
+fn unpack(aminos: &mut [Amino], packed: &[u8]) {
+    let (pairs, packed_remainder) = packed.as_chunks();
+    let (triplets, amino_remainder) = aminos.as_chunks_mut();
+    for ([a1, a2, a3], &pair) in triplets.iter_mut().zip(pairs) {
+        let val = u16::from_be_bytes(pair);
+        *a1 = Amino::decompress(val >> 10);
+        *a2 = Amino::decompress(val >> 5);
+        *a3 = Amino::decompress(val);
+    }
+    match (amino_remainder, packed_remainder) {
+        ([], []) => {}
+        ([a1], &[b1]) => {
+            *a1 = Amino::decompress(u16::from_be_bytes([b1, 0]) >> 10);
+        }
+        ([a1, a2], []) => {
+            let val = u16::from_be_bytes(*pairs.last().unwrap());
+            *a1 = Amino::decompress(val >> 10);
+            *a2 = Amino::decompress(val >> 5);
+        }
+        _ => panic!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{arbitrary::any, proptest};
+
+    use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
+    use crate::proptest::any_peptide;
+
+    use super::*;
+
+    #[test]
+    fn all_short_roundtrips() {
+        // Yes, this is hideously ugly, but arrays need a size known at compile-time,
+        // and this is the simplest way to ensure I get them all.
+        assert_both_roundtrips(&[] as &[Amino; 0]);
+        for a1 in Amino::ALL {
+            assert_both_roundtrips(&[a1]);
+            for a2 in Amino::ALL {
+                assert_both_roundtrips(&[a1, a2]);
+                for a3 in Amino::ALL {
+                    assert_both_roundtrips(&[a1, a2, a3]);
+                    for a4 in Amino::ALL {
+                        assert_both_roundtrips(&[a1, a2, a3, a4]);
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_peptide_roundtrip(
+            peptide in any_peptide(5..25) // 0..=4 covered above
+        ) {
+            assert_roundtrip(&*peptide);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide5_roundtrip(
+            peptide in any::<[Amino; 5]>()
+        ) {
+            assert_roundtrip(&peptide);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide6_roundtrip(
+            peptide in any::<[Amino; 6]>()
+        ) {
+            assert_roundtrip(&peptide);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide7_roundtrip(
+            peptide in any::<[Amino; 7]>()
+        ) {
+            assert_roundtrip(&peptide);
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_peptide_lexical_ordering(
+            peptide1 in any_peptide(0..50),
+            peptide2 in any_peptide(0..50),
+        ) {
+            let packed1 = PackedPeptide::from(peptide1.as_slice());
+            let packed2 = PackedPeptide::from(peptide2.as_slice());
+            assert_eq!(packed1.0.cmp(&packed2.0), peptide1.cmp(&peptide2));
+        }
+    }
+}


### PR DESCRIPTION
This is missing lots of important features, but it at least enables less memory use, both for `Vec`s and arrays, for all `Symbol` types.
