### PR TITLE
Mark slow tests as ignored in MIRI.

### DIFF
--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -143,6 +143,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn all_short_roundtrips() {
         // Yes, this is hideously ugly, but arrays need a size known at compile-time,

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -163,6 +163,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn all_short_roundtrips() {
         // Yes, this is hideously ugly, but arrays need a size known at compile-time,

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -165,6 +165,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
     #[test]
     fn all_short_roundtrips() {
         // Yes, this is hideously ugly, but arrays need a size known at compile-time,


### PR DESCRIPTION
Get CI back on track before moving on to fix the incorrect merge check rule.