### PR TITLE
Tweak names: nucs -> dna, aminos -> peptide

### DIFF
--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -23,27 +23,27 @@ use super::{ArrayDefault, ArrayDivide};
 pub struct PackedAmbiDna(Vec<u8>);
 
 impl From<&[AmbiNuc]> for PackedAmbiDna {
-    fn from(ambi_nucs: &[AmbiNuc]) -> PackedAmbiDna {
-        let packed_len = ambi_nucs.len().div_ceil(2);
+    fn from(ambi_dna: &[AmbiNuc]) -> PackedAmbiDna {
+        let packed_len = ambi_dna.len().div_ceil(2);
         let mut packed = vec![0; packed_len];
-        pack(&mut packed, ambi_nucs);
+        pack(&mut packed, ambi_dna);
         Self(packed)
     }
 }
 
 impl From<PackedAmbiDna> for Vec<AmbiNuc> {
-    fn from(packed_ambi_nucs: PackedAmbiDna) -> Vec<AmbiNuc> {
-        (&packed_ambi_nucs).into()
+    fn from(packed_ambi_dna: PackedAmbiDna) -> Vec<AmbiNuc> {
+        (&packed_ambi_dna).into()
     }
 }
 
 impl From<&PackedAmbiDna> for Vec<AmbiNuc> {
-    fn from(packed_ambi_nucs: &PackedAmbiDna) -> Vec<AmbiNuc> {
-        if let Some(byte) = packed_ambi_nucs.0.last() {
-            let len = 2 * packed_ambi_nucs.0.len() - usize::from(byte.trailing_zeros() >= 4);
-            let mut ambi_nucs = vec![AmbiNuc::default(); len];
-            unpack(&mut ambi_nucs, &packed_ambi_nucs.0);
-            ambi_nucs
+    fn from(packed_ambi_dna: &PackedAmbiDna) -> Vec<AmbiNuc> {
+        if let Some(byte) = packed_ambi_dna.0.last() {
+            let len = 2 * packed_ambi_dna.0.len() - usize::from(byte.trailing_zeros() >= 4);
+            let mut ambi_dna = vec![AmbiNuc::default(); len];
+            unpack(&mut ambi_dna, &packed_ambi_dna.0);
+            ambi_dna
         } else {
             vec![]
         }
@@ -73,8 +73,8 @@ impl<const N: usize> From<[AmbiNuc; N]> for PackedArrayAmbiDna<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(ambi_nucs: [AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
-        (&ambi_nucs).into()
+    fn from(ambi_dna: [AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
+        (&ambi_dna).into()
     }
 }
 
@@ -82,9 +82,9 @@ impl<const N: usize> From<&[AmbiNuc; N]> for PackedArrayAmbiDna<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(ambi_nucs: &[AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
+    fn from(ambi_dna: &[AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
         let mut this = Self(ArrayDefault::array_default());
-        pack(this.0.as_mut(), ambi_nucs);
+        pack(this.0.as_mut(), ambi_dna);
         this
     }
 }
@@ -93,8 +93,8 @@ impl<const N: usize> From<PackedArrayAmbiDna<N>> for [AmbiNuc; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_ambi_nucs: PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
-        (&packed_ambi_nucs).into()
+    fn from(packed_ambi_dna: PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
+        (&packed_ambi_dna).into()
     }
 }
 
@@ -102,15 +102,15 @@ impl<const N: usize> From<&PackedArrayAmbiDna<N>> for [AmbiNuc; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_ambi_nucs: &PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
-        let mut ambi_nucs = [AmbiNuc::default(); N];
-        unpack(&mut ambi_nucs, packed_ambi_nucs.0.as_ref());
-        ambi_nucs
+    fn from(packed_ambi_dna: &PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
+        let mut ambi_dna = [AmbiNuc::default(); N];
+        unpack(&mut ambi_dna, packed_ambi_dna.0.as_ref());
+        ambi_dna
     }
 }
 
-fn pack(packed: &mut [u8], ambi_nucs: &[AmbiNuc]) {
-    let (pairs, remainder) = ambi_nucs.as_chunks();
+fn pack(packed: &mut [u8], ambi_dna: &[AmbiNuc]) {
+    let (pairs, remainder) = ambi_dna.as_chunks();
     for (byte, &[n1, n2]) in packed.iter_mut().zip(pairs) {
         *byte = n2.compress() | (n1.compress() << 4);
     }
@@ -121,8 +121,8 @@ fn pack(packed: &mut [u8], ambi_nucs: &[AmbiNuc]) {
     }
 }
 
-fn unpack(ambi_nucs: &mut [AmbiNuc], packed: &[u8]) {
-    let (pairs, remainder) = ambi_nucs.as_chunks_mut();
+fn unpack(ambi_dna: &mut [AmbiNuc], packed: &[u8]) {
+    let (pairs, remainder) = ambi_dna.as_chunks_mut();
     for ([n1, n2], &byte) in pairs.iter_mut().zip(packed) {
         *n1 = AmbiNuc::decompress(byte >> 4);
         *n2 = AmbiNuc::decompress(byte);

--- a/src/packed/ambipeptide.rs
+++ b/src/packed/ambipeptide.rs
@@ -20,20 +20,20 @@ use crate::AmbiAmino;
 pub struct PackedAmbiPeptide(Vec<[u8; 3]>);
 
 impl From<&[AmbiAmino]> for PackedAmbiPeptide {
-    fn from(ambi_aminos: &[AmbiAmino]) -> PackedAmbiPeptide {
-        Self(ambi_aminos.iter().map(|a| a.compress()).collect())
+    fn from(ambi_peptide: &[AmbiAmino]) -> PackedAmbiPeptide {
+        Self(ambi_peptide.iter().map(|a| a.compress()).collect())
     }
 }
 
 impl From<PackedAmbiPeptide> for Vec<AmbiAmino> {
-    fn from(packed_ambi_aminos: PackedAmbiPeptide) -> Vec<AmbiAmino> {
-        (&packed_ambi_aminos).into()
+    fn from(packed_ambi_peptide: PackedAmbiPeptide) -> Vec<AmbiAmino> {
+        (&packed_ambi_peptide).into()
     }
 }
 
 impl From<&PackedAmbiPeptide> for Vec<AmbiAmino> {
-    fn from(packed_ambi_aminos: &PackedAmbiPeptide) -> Vec<AmbiAmino> {
-        let packed = packed_ambi_aminos.0.iter();
+    fn from(packed_ambi_peptide: &PackedAmbiPeptide) -> Vec<AmbiAmino> {
+        let packed = packed_ambi_peptide.0.iter();
         packed.map(|&bits| AmbiAmino::decompress(bits)).collect()
     }
 }
@@ -56,26 +56,26 @@ impl From<&PackedAmbiPeptide> for Vec<AmbiAmino> {
 pub struct PackedArrayAmbiPeptide<const N: usize>([[u8; 3]; N]);
 
 impl<const N: usize> From<[AmbiAmino; N]> for PackedArrayAmbiPeptide<N> {
-    fn from(ambi_aminos: [AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
-        (&ambi_aminos).into()
+    fn from(ambi_peptide: [AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
+        (&ambi_peptide).into()
     }
 }
 
 impl<const N: usize> From<&[AmbiAmino; N]> for PackedArrayAmbiPeptide<N> {
-    fn from(ambi_aminos: &[AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
-        Self(ambi_aminos.map(AmbiAmino::compress))
+    fn from(ambi_peptide: &[AmbiAmino; N]) -> PackedArrayAmbiPeptide<N> {
+        Self(ambi_peptide.map(AmbiAmino::compress))
     }
 }
 
 impl<const N: usize> From<PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
-    fn from(packed_ambi_aminos: PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
-        (&packed_ambi_aminos).into()
+    fn from(packed_ambi_peptide: PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
+        (&packed_ambi_peptide).into()
     }
 }
 
 impl<const N: usize> From<&PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
-    fn from(packed_ambi_aminos: &PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
-        packed_ambi_aminos.0.map(AmbiAmino::decompress)
+    fn from(packed_ambi_peptide: &PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
+        packed_ambi_peptide.0.map(AmbiAmino::decompress)
     }
 }
 

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -29,34 +29,34 @@ use super::{ArrayDefault, ArrayDivide};
 pub struct PackedDna(Vec<u8>);
 
 impl From<&[Nuc]> for PackedDna {
-    fn from(nucs: &[Nuc]) -> PackedDna {
-        let packed_len = match nucs.len() {
+    fn from(dna: &[Nuc]) -> PackedDna {
+        let packed_len = match dna.len() {
             0 => 0, // special-case to reduce allocs
             l => l / 4 + 1,
         };
         let mut packed = vec![0; packed_len];
-        pack(&mut packed, nucs);
+        pack(&mut packed, dna);
         if let Some(byte) = packed.last_mut() {
             *byte |=
-                u8::try_from(nucs.len() % 4).unwrap_or_else(|_| unreachable!("x % 4 fits in a u8"));
+                u8::try_from(dna.len() % 4).unwrap_or_else(|_| unreachable!("x % 4 fits in a u8"));
         }
         Self(packed)
     }
 }
 
 impl From<PackedDna> for Vec<Nuc> {
-    fn from(packed_nucs: PackedDna) -> Vec<Nuc> {
-        (&packed_nucs).into()
+    fn from(packed_dna: PackedDna) -> Vec<Nuc> {
+        (&packed_dna).into()
     }
 }
 
 impl From<&PackedDna> for Vec<Nuc> {
-    fn from(packed_nucs: &PackedDna) -> Vec<Nuc> {
-        if let Some(byte) = packed_nucs.0.last() {
-            let len = 4 * (packed_nucs.0.len() - 1) + (byte & 0b11) as usize;
-            let mut nucs = vec![Nuc::default(); len];
-            unpack(&mut nucs, &packed_nucs.0);
-            nucs
+    fn from(packed_dna: &PackedDna) -> Vec<Nuc> {
+        if let Some(byte) = packed_dna.0.last() {
+            let len = 4 * (packed_dna.0.len() - 1) + (byte & 0b11) as usize;
+            let mut dna = vec![Nuc::default(); len];
+            unpack(&mut dna, &packed_dna.0);
+            dna
         } else {
             vec![]
         }
@@ -86,8 +86,8 @@ impl<const N: usize> From<[Nuc; N]> for PackedArrayDna<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(nucs: [Nuc; N]) -> PackedArrayDna<N> {
-        (&nucs).into()
+    fn from(dna: [Nuc; N]) -> PackedArrayDna<N> {
+        (&dna).into()
     }
 }
 
@@ -95,9 +95,9 @@ impl<const N: usize> From<&[Nuc; N]> for PackedArrayDna<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(nucs: &[Nuc; N]) -> PackedArrayDna<N> {
+    fn from(dna: &[Nuc; N]) -> PackedArrayDna<N> {
         let mut this = Self(ArrayDefault::array_default());
-        pack(this.0.as_mut(), nucs);
+        pack(this.0.as_mut(), dna);
         this
     }
 }
@@ -106,8 +106,8 @@ impl<const N: usize> From<PackedArrayDna<N>> for [Nuc; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_nucs: PackedArrayDna<N>) -> [Nuc; N] {
-        (&packed_nucs).into()
+    fn from(packed_dna: PackedArrayDna<N>) -> [Nuc; N] {
+        (&packed_dna).into()
     }
 }
 
@@ -115,15 +115,15 @@ impl<const N: usize> From<&PackedArrayDna<N>> for [Nuc; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_nucs: &PackedArrayDna<N>) -> [Nuc; N] {
-        let mut nucs = [Nuc::default(); N];
-        unpack(&mut nucs, packed_nucs.0.as_ref());
-        nucs
+    fn from(packed_dna: &PackedArrayDna<N>) -> [Nuc; N] {
+        let mut dna = [Nuc::default(); N];
+        unpack(&mut dna, packed_dna.0.as_ref());
+        dna
     }
 }
 
-fn pack(packed: &mut [u8], nucs: &[Nuc]) {
-    let (quads, remainder) = nucs.as_chunks();
+fn pack(packed: &mut [u8], dna: &[Nuc]) {
+    let (quads, remainder) = dna.as_chunks();
     for (byte, &[n1, n2, n3, n4]) in packed.iter_mut().zip(quads) {
         *byte = n4.compress() | (n3.compress() << 2) | (n2.compress() << 4) | (n1.compress() << 6);
     }
@@ -137,8 +137,8 @@ fn pack(packed: &mut [u8], nucs: &[Nuc]) {
     }
 }
 
-fn unpack(nucs: &mut [Nuc], packed: &[u8]) {
-    let (quads, remainder) = nucs.as_chunks_mut();
+fn unpack(dna: &mut [Nuc], packed: &[u8]) {
+    let (quads, remainder) = dna.as_chunks_mut();
     for ([n1, n2, n3, n4], &byte) in quads.iter_mut().zip(packed) {
         *n4 = Nuc::decompress(byte);
         *n3 = Nuc::decompress(byte >> 2);

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -28,32 +28,32 @@ use super::{ArrayDefault, ArrayDivide};
 pub struct PackedPeptide(Vec<u8>);
 
 impl From<&[Amino]> for PackedPeptide {
-    fn from(aminos: &[Amino]) -> PackedPeptide {
-        let packed_len = (2 * aminos.len()).div_ceil(3);
+    fn from(peptide: &[Amino]) -> PackedPeptide {
+        let packed_len = (2 * peptide.len()).div_ceil(3);
         let mut packed = vec![0; packed_len];
-        pack(&mut packed, aminos);
+        pack(&mut packed, peptide);
         Self(packed)
     }
 }
 
 impl From<PackedPeptide> for Vec<Amino> {
-    fn from(packed_aminos: PackedPeptide) -> Vec<Amino> {
-        (&packed_aminos).into()
+    fn from(packed_peptide: PackedPeptide) -> Vec<Amino> {
+        (&packed_peptide).into()
     }
 }
 
 impl From<&PackedPeptide> for Vec<Amino> {
-    fn from(packed_aminos: &PackedPeptide) -> Vec<Amino> {
-        let len = match packed_aminos.0.as_chunks::<2>() {
+    fn from(packed_peptide: &PackedPeptide) -> Vec<Amino> {
+        let len = match packed_peptide.0.as_chunks::<2>() {
             (pairs, [_]) => 3 * pairs.len() + 1,
             (pairs @ [.., last_pair], []) => {
                 3 * pairs.len() - (u16::from_be_bytes(*last_pair).trailing_zeros() / 5) as usize
             }
             _ => return vec![],
         };
-        let mut aminos = vec![Amino::default(); len];
-        unpack(&mut aminos, &packed_aminos.0);
-        aminos
+        let mut peptide = vec![Amino::default(); len];
+        unpack(&mut peptide, &packed_peptide.0);
+        peptide
     }
 }
 
@@ -80,8 +80,8 @@ impl<const N: usize> From<[Amino; N]> for PackedArrayPeptide<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(aminos: [Amino; N]) -> PackedArrayPeptide<N> {
-        (&aminos).into()
+    fn from(peptide: [Amino; N]) -> PackedArrayPeptide<N> {
+        (&peptide).into()
     }
 }
 
@@ -89,9 +89,9 @@ impl<const N: usize> From<&[Amino; N]> for PackedArrayPeptide<N>
 where
     [(); N]: ArrayDivide,
 {
-    fn from(aminos: &[Amino; N]) -> PackedArrayPeptide<N> {
+    fn from(peptide: &[Amino; N]) -> PackedArrayPeptide<N> {
         let mut this = Self(ArrayDefault::array_default());
-        pack(this.0.as_mut(), aminos);
+        pack(this.0.as_mut(), peptide);
         this
     }
 }
@@ -100,8 +100,8 @@ impl<const N: usize> From<PackedArrayPeptide<N>> for [Amino; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_aminos: PackedArrayPeptide<N>) -> [Amino; N] {
-        (&packed_aminos).into()
+    fn from(packed_peptide: PackedArrayPeptide<N>) -> [Amino; N] {
+        (&packed_peptide).into()
     }
 }
 
@@ -109,20 +109,20 @@ impl<const N: usize> From<&PackedArrayPeptide<N>> for [Amino; N]
 where
     [(); N]: ArrayDivide,
 {
-    fn from(packed_aminos: &PackedArrayPeptide<N>) -> [Amino; N] {
-        let mut aminos = [Amino::default(); N];
-        unpack(&mut aminos, packed_aminos.0.as_ref());
-        aminos
+    fn from(packed_peptide: &PackedArrayPeptide<N>) -> [Amino; N] {
+        let mut peptide = [Amino::default(); N];
+        unpack(&mut peptide, packed_peptide.0.as_ref());
+        peptide
     }
 }
 
-fn pack(packed: &mut [u8], aminos: &[Amino]) {
+fn pack(packed: &mut [u8], peptide: &[Amino]) {
     let (pairs, packed_remainder) = packed.as_chunks_mut();
-    let (triplets, amino_remainder) = aminos.as_chunks();
+    let (triplets, peptide_remainder) = peptide.as_chunks();
     for (pair, &[a1, a2, a3]) in pairs.iter_mut().zip(triplets) {
         *pair = (a3.compress() | (a2.compress() << 5) | (a1.compress() << 10)).to_be_bytes();
     }
-    match (packed_remainder, amino_remainder) {
+    match (packed_remainder, peptide_remainder) {
         ([], []) => {}
         ([b1], &[a1]) => [*b1, _] = (a1.compress() << 10).to_be_bytes(),
         ([], &[a1, a2]) => {
@@ -133,16 +133,16 @@ fn pack(packed: &mut [u8], aminos: &[Amino]) {
     }
 }
 
-fn unpack(aminos: &mut [Amino], packed: &[u8]) {
+fn unpack(peptide: &mut [Amino], packed: &[u8]) {
     let (pairs, packed_remainder) = packed.as_chunks();
-    let (triplets, amino_remainder) = aminos.as_chunks_mut();
+    let (triplets, peptide_remainder) = peptide.as_chunks_mut();
     for ([a1, a2, a3], &pair) in triplets.iter_mut().zip(pairs) {
         let val = u16::from_be_bytes(pair);
         *a1 = Amino::decompress(val >> 10);
         *a2 = Amino::decompress(val >> 5);
         *a3 = Amino::decompress(val);
     }
-    match (amino_remainder, packed_remainder) {
+    match (peptide_remainder, packed_remainder) {
         ([], []) => {}
         ([a1], &[b1]) => {
             *a1 = Amino::decompress(u16::from_be_bytes([b1, 0]) >> 10);


### PR DESCRIPTION
Elsewhere I refer to nuc sequences as DNA and amino acid sequences as peptide. I mostly updated the packed code to match that but forgot the variable names themselves.