### PR TITLE
Seal `ArrayDivide`, renaming it to `PackableArray`.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * `Seq` now has `complement` and `reverse_complement` methods. (#61)
-* Add basic support for packed types! (#62)
+* Add basic support for packed types! (#62, #66)
 
 ## Version 0.4.0 (2026-07-28)
 

--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -1,6 +1,7 @@
 use crate::AmbiNuc;
 
-use super::{ArrayDefault, ArrayDivide};
+use super::PackableArray;
+use super::packable_array::{ArrayDefault, Sealed as ArrayDivide};
 
 // Note on storage: AmbiNucs are packed big-endian so naive lexical sorting of bytes is correct.
 //
@@ -67,11 +68,11 @@ impl From<&PackedAmbiDna> for Vec<AmbiNuc> {
 #[derive(Clone, Copy)]
 pub struct PackedArrayAmbiDna<const N: usize>(<[(); N] as ArrayDivide>::By2<u8>)
 where
-    [(); N]: ArrayDivide;
+    [(); N]: PackableArray;
 
 impl<const N: usize> From<[AmbiNuc; N]> for PackedArrayAmbiDna<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(ambi_dna: [AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
         (&ambi_dna).into()
@@ -80,7 +81,7 @@ where
 
 impl<const N: usize> From<&[AmbiNuc; N]> for PackedArrayAmbiDna<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(ambi_dna: &[AmbiNuc; N]) -> PackedArrayAmbiDna<N> {
         let mut this = Self(ArrayDefault::array_default());
@@ -91,7 +92,7 @@ where
 
 impl<const N: usize> From<PackedArrayAmbiDna<N>> for [AmbiNuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_ambi_dna: PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
         (&packed_ambi_dna).into()
@@ -100,7 +101,7 @@ where
 
 impl<const N: usize> From<&PackedArrayAmbiDna<N>> for [AmbiNuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_ambi_dna: &PackedArrayAmbiDna<N>) -> [AmbiNuc; N] {
         let mut ambi_dna = [AmbiNuc::default(); N];

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -1,6 +1,7 @@
 use crate::Nuc;
 
-use super::{ArrayDefault, ArrayDivide};
+use super::PackableArray;
+use super::packable_array::{ArrayDefault, Sealed as ArrayDivide};
 
 // Note on storage: Nucs are packed big-endian. Sadly, this encoding DOES NOT maintain lexical
 // ordering, due to the suffix (see below).
@@ -80,11 +81,11 @@ impl From<&PackedDna> for Vec<Nuc> {
 #[derive(Clone, Copy)]
 pub struct PackedArrayDna<const N: usize>(<[(); N] as ArrayDivide>::By4<u8>)
 where
-    [(); N]: ArrayDivide;
+    [(); N]: PackableArray;
 
 impl<const N: usize> From<[Nuc; N]> for PackedArrayDna<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(dna: [Nuc; N]) -> PackedArrayDna<N> {
         (&dna).into()
@@ -93,7 +94,7 @@ where
 
 impl<const N: usize> From<&[Nuc; N]> for PackedArrayDna<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(dna: &[Nuc; N]) -> PackedArrayDna<N> {
         let mut this = Self(ArrayDefault::array_default());
@@ -104,7 +105,7 @@ where
 
 impl<const N: usize> From<PackedArrayDna<N>> for [Nuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_dna: PackedArrayDna<N>) -> [Nuc; N] {
         (&packed_dna).into()
@@ -113,7 +114,7 @@ where
 
 impl<const N: usize> From<&PackedArrayDna<N>> for [Nuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_dna: &PackedArrayDna<N>) -> [Nuc; N] {
         let mut dna = [Nuc::default(); N];

--- a/src/packed/mod.rs
+++ b/src/packed/mod.rs
@@ -39,7 +39,7 @@ impl Packable for [Nuc] {
 
 impl<const N: usize> Packable for [Nuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     type Packed = PackedArrayDna<N>;
 }
@@ -50,7 +50,7 @@ impl Packable for [AmbiNuc] {
 
 impl<const N: usize> Packable for [AmbiNuc; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     type Packed = PackedArrayAmbiDna<N>;
 }
@@ -61,7 +61,7 @@ impl Packable for [Amino] {
 
 impl<const N: usize> Packable for [Amino; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     type Packed = PackedArrayPeptide<N>;
 }
@@ -74,45 +74,47 @@ impl<const N: usize> Packable for [AmbiAmino; N] {
     type Packed = PackedArrayAmbiPeptide<N>;
 }
 
-/// Utility trait used to work out packed array sizes at compile-time.
-///
-/// The API/details of this are intended for internal use and are therefore unstable.
-pub trait ArrayDivide {
-    // `ArrayDivide` uses GATs rather than constants to work around limitations in the current
-    // trait solver: A type/trait can't declare an array with a length obtained from a trait's
-    // associated constant.
-    //
-    // In theory, we could use non-generic associated types by setting them to something like
-    // `[(); N]` and matching a const generic parameter against them, but that ends up introducing
-    // additional generic parameters into types, and more implementation-specific trait constraints
-    // into everything else, so it'd make the public API horribly complicated.
+/// An array for which packed sizes are known.
+pub trait PackableArray: packable_array::Sealed {}
 
-    /// `[T; (2 * self.len()).div_ceil(3)]`
-    type By3_2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
-    /// `[T; self.len().div_ceil(2)]`
-    type By2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
-    /// `[T; self.len().div_ceil(4)]`
-    type By4<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
-}
+pub(crate) mod packable_array {
+    /// Implementation details of [`PackedArray`].
+    ///
+    /// This uses GATs rather than constants to work around limitations in the current
+    /// trait solver: A type/trait can't declare an array with a length obtained from a
+    /// trait's associated constant.
+    ///
+    /// In theory, we could use non-generic associated types by setting them to something
+    /// like `[(); N]` and matching a const generic parameter against them, but that ends up
+    /// introducing additional generic parameters into types, and more implementation-specific
+    /// trait constraints into everything else, complicating the public APIs.
+    pub trait Sealed {
+        /// `[T; (2 * N).div_ceil(3)]`
+        type By3_2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+        /// `[T; N.div_ceil(2)]`
+        type By2<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+        /// `[T; N.div_ceil(4)]`
+        type By4<T: Copy + Default>: AsRef<[T]> + AsMut<[T]> + Copy + ArrayDefault;
+    }
 
-/// Workaround for `[T; N]: Default` being limited to `N <= 32`
-///
-/// This is intended more as an internal implementation detail.
-pub trait ArrayDefault {
-    /// [`[T; N]::default`](Default#impl-Default-for-[T;+32]), but extended to any `N`.
-    fn array_default() -> Self;
-}
+    /// Workaround for `[T; N]: Default` being limited to `N <= 32`.
+    pub trait ArrayDefault {
+        fn array_default() -> Self;
+    }
 
-impl<T: Default, const N: usize> ArrayDefault for [T; N] {
-    fn array_default() -> Self {
-        std::array::from_fn(|_| T::default())
+    impl<T: Default, const N: usize> ArrayDefault for [T; N] {
+        fn array_default() -> Self {
+            std::array::from_fn(|_| T::default())
+        }
     }
 }
 
 macro_rules! div_table {
     ( $( $d:literal => $q3_2:literal $q2:literal $q4:literal),+ , ) => {
         $(
-            impl ArrayDivide for [(); $d] {
+            impl PackableArray for [(); $d] {}
+
+            impl packable_array::Sealed for [(); $d] {
                 type By3_2<T: Copy + Default> = [T; $q3_2];
                 type By2<T: Copy + Default> = [T; $q2];
                 type By4<T: Copy + Default> = [T; $q4];

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -1,6 +1,7 @@
 use crate::Amino;
 
-use super::{ArrayDefault, ArrayDivide};
+use super::PackableArray;
+use super::packable_array::{ArrayDefault, Sealed as ArrayDivide};
 
 // Note on storage: Aminos are packed big-endian so naive lexical sorting of bytes is correct.
 // The [u8; 2] themselves are big-endian u16s, for the same reason.
@@ -74,11 +75,11 @@ impl From<&PackedPeptide> for Vec<Amino> {
 #[derive(Clone, Copy)]
 pub struct PackedArrayPeptide<const N: usize>(<[(); N] as ArrayDivide>::By3_2<u8>)
 where
-    [(); N]: ArrayDivide;
+    [(); N]: PackableArray;
 
 impl<const N: usize> From<[Amino; N]> for PackedArrayPeptide<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(peptide: [Amino; N]) -> PackedArrayPeptide<N> {
         (&peptide).into()
@@ -87,7 +88,7 @@ where
 
 impl<const N: usize> From<&[Amino; N]> for PackedArrayPeptide<N>
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(peptide: &[Amino; N]) -> PackedArrayPeptide<N> {
         let mut this = Self(ArrayDefault::array_default());
@@ -98,7 +99,7 @@ where
 
 impl<const N: usize> From<PackedArrayPeptide<N>> for [Amino; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_peptide: PackedArrayPeptide<N>) -> [Amino; N] {
         (&packed_peptide).into()
@@ -107,7 +108,7 @@ where
 
 impl<const N: usize> From<&PackedArrayPeptide<N>> for [Amino; N]
 where
-    [(); N]: ArrayDivide,
+    [(); N]: PackableArray,
 {
     fn from(packed_peptide: &PackedArrayPeptide<N>) -> [Amino; N] {
         let mut peptide = [Amino::default(); N];


### PR DESCRIPTION
This hides implementation details that were never really intended to be accessible. Likewise, `ArrayDefault` is no longer accessible.