### PR TITLE
Add basic `{Partial,}{Eq,Ord}` impls for packed types.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 * `Seq` now has `complement` and `reverse_complement` methods. (#61)
 * `Seq` now supports `AsRef` and `AsMut`. (#67)
-* Add basic support for packed types! (#62, #66, #69, #70, #73, #74)
+* Add basic support for packed types! (#62, #66, #69, #70, #73, #74, #75)
 
 ## Version 0.4.0 (2026-07-28)
 

--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -1,5 +1,6 @@
 //! Types related to packed ambiguous DNA.
 
+use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{AmbiNuc, Seq, iter::display};
@@ -114,6 +115,26 @@ impl IntoIterator for PackedAmbiDna {
 
     fn into_iter(self) -> Self::IntoIter {
         PackedAmbiDnaIntoIter(UnpackingIter::new(0..self.len(), self.0))
+    }
+}
+
+impl PartialEq for PackedAmbiDna {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl Eq for PackedAmbiDna {}
+
+impl PartialOrd for PackedAmbiDna {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PackedAmbiDna {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
     }
 }
 
@@ -260,6 +281,35 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayAmbiDnaIntoIter(UnpackingIter::new(0..N, self.0))
+    }
+}
+
+impl<const N: usize> PartialEq for PackedArrayAmbiDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref().eq(other.0.as_ref())
+    }
+}
+
+impl<const N: usize> Eq for PackedArrayAmbiDna<N> where [(); N]: PackableArray {}
+
+impl<const N: usize> PartialOrd for PackedArrayAmbiDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for PackedArrayAmbiDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -577,6 +627,54 @@ mod tests {
             let packed = PackedAmbiDna::from(&ambi_dna);
             assert_eq!(packed.len(), ambi_dna.len());
             assert_eq!(packed.is_empty(), ambi_dna.is_empty());
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_dna_ord(
+            ambi_dna1 in any_ambi_dna(0..50),
+            ambi_dna2 in any_ambi_dna(0..50),
+        ) {
+            let packed1 = PackedAmbiDna::from(&ambi_dna1);
+            let packed2 = PackedAmbiDna::from(&ambi_dna2);
+            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
+            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna1_ord(
+            ambi_dna1 in any::<[AmbiNuc; 1]>(),
+            ambi_dna2 in any::<[AmbiNuc; 1]>(),
+        ) {
+            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
+            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
+            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
+            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna2_ord(
+            ambi_dna1 in any::<[AmbiNuc; 2]>(),
+            ambi_dna2 in any::<[AmbiNuc; 2]>(),
+        ) {
+            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
+            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
+            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
+            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna3_ord(
+            ambi_dna1 in any::<[AmbiNuc; 3]>(),
+            ambi_dna2 in any::<[AmbiNuc; 3]>(),
+        ) {
+            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
+            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
+            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
+            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
         }
     }
 }

--- a/src/packed/ambipeptide.rs
+++ b/src/packed/ambipeptide.rs
@@ -1,5 +1,6 @@
 //! Types related to packed ambiguous peptides.
 
+use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{AmbiAmino, Seq, iter::display};
@@ -105,6 +106,26 @@ impl IntoIterator for PackedAmbiPeptide {
     }
 }
 
+impl PartialEq for PackedAmbiPeptide {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_flattened().eq(other.0.as_flattened())
+    }
+}
+
+impl Eq for PackedAmbiPeptide {}
+
+impl PartialOrd for PackedAmbiPeptide {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PackedAmbiPeptide {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_flattened().cmp(other.0.as_flattened())
+    }
+}
+
 impl std::fmt::Display for PackedAmbiPeptide {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         self.iter().fmt(f)
@@ -189,6 +210,26 @@ impl<const N: usize> From<PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
 impl<const N: usize> From<&PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
     fn from(packed_ambi_peptide: &PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
         packed_ambi_peptide.0.map(AmbiAmino::decompress)
+    }
+}
+
+impl<const N: usize> PartialEq for PackedArrayAmbiPeptide<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_flattened().eq(other.0.as_flattened())
+    }
+}
+
+impl<const N: usize> Eq for PackedArrayAmbiPeptide<N> {}
+
+impl<const N: usize> PartialOrd for PackedArrayAmbiPeptide<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for PackedArrayAmbiPeptide<N> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_flattened().cmp(other.0.as_flattened())
     }
 }
 
@@ -366,6 +407,7 @@ impl std::fmt::Debug for PackedAmbiPeptideIter<'_> {
 
 #[cfg(test)]
 mod tests {
+    use proptest::arbitrary::any;
     use proptest::proptest;
 
     use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
@@ -433,6 +475,43 @@ mod tests {
             let packed = PackedAmbiPeptide::from(&ambi_peptide);
             assert_eq!(packed.len(), ambi_peptide.len());
             assert_eq!(packed.is_empty(), ambi_peptide.is_empty());
+        }
+
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_ambi_peptide_ord(
+            ambi_peptide1 in any_ambi_peptide(0..50),
+            ambi_peptide2 in any_ambi_peptide(0..50),
+        ) {
+            let packed1 = PackedAmbiPeptide::from(&ambi_peptide1);
+            let packed2 = PackedAmbiPeptide::from(&ambi_peptide2);
+            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
+            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_ambi_peptide1_ord(
+            ambi_peptide1 in any::<[AmbiAmino; 1]>(),
+            ambi_peptide2 in any::<[AmbiAmino; 1]>(),
+        ) {
+            let packed1 = PackedArrayAmbiPeptide::from(&ambi_peptide1);
+            let packed2 = PackedArrayAmbiPeptide::from(&ambi_peptide2);
+            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
+            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide2_ord(
+            ambi_peptide1 in any::<[AmbiAmino; 2]>(),
+            ambi_peptide2 in any::<[AmbiAmino; 2]>(),
+        ) {
+            let packed1 = PackedArrayAmbiPeptide::from(&ambi_peptide1);
+            let packed2 = PackedArrayAmbiPeptide::from(&ambi_peptide2);
+            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
+            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
         }
     }
 }

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -1,5 +1,6 @@
 //! Types related to packed DNA.
 
+use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{Nuc, Seq, iter::display};
@@ -127,6 +128,46 @@ impl IntoIterator for PackedDna {
 
     fn into_iter(self) -> Self::IntoIter {
         PackedDnaIntoIter(UnpackingIter::new(0..self.len(), self.0))
+    }
+}
+
+impl PartialEq for PackedDna {
+    fn eq(&self, other: &Self) -> bool {
+        match (&*self.0, &*other.0) {
+            ([], [0]) | ([0], []) => true,
+            (x, y) => x == y,
+        }
+    }
+}
+
+impl Eq for PackedDna {}
+
+impl PartialOrd for PackedDna {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PackedDna {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&*self.0, &*other.0) {
+            ([] | [0], [] | [0]) => Ordering::Equal,
+            ([] | [0], _) => Ordering::Less,
+            (_, [] | [0]) => Ordering::Greater,
+            ([x_bulk @ .., x_last], [y_bulk @ .., y_last]) => {
+                let common_prefix_len = x_bulk.len().min(y_bulk.len());
+                let (x_prefix, x_remainder) = x_bulk.split_at(common_prefix_len);
+                let (y_prefix, y_remainder) = y_bulk.split_at(common_prefix_len);
+                x_prefix
+                    .cmp(y_prefix)
+                    .then_with(|| match (x_remainder, y_remainder) {
+                        ([], []) => x_last.cmp(y_last),
+                        ([], [y_next, ..]) => (x_last & !0b11).cmp(y_next).then(Ordering::Less),
+                        ([x_next, ..], []) => x_next.cmp(&(y_last & !0b11)).then(Ordering::Greater),
+                        _ => unreachable!(),
+                    })
+            }
+        }
     }
 }
 
@@ -273,6 +314,35 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayDnaIntoIter(UnpackingIter::new(0..N, self.0))
+    }
+}
+
+impl<const N: usize> PartialEq for PackedArrayDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref().eq(other.0.as_ref())
+    }
+}
+
+impl<const N: usize> Eq for PackedArrayDna<N> where [(); N]: PackableArray {}
+
+impl<const N: usize> PartialOrd for PackedArrayDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for PackedArrayDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -614,6 +684,78 @@ mod tests {
             let packed = PackedDna::from(&dna);
             assert_eq!(packed.len(), dna.len());
             assert_eq!(packed.is_empty(), dna.is_empty());
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_dna_ord(
+            dna1 in any_dna(0..50),
+            dna2 in any_dna(0..50),
+        ) {
+            let packed1 = PackedDna::from(&dna1);
+            let packed2 = PackedDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna1_ord(
+            dna1 in any::<[Nuc; 1]>(),
+            dna2 in any::<[Nuc; 1]>(),
+        ) {
+            let packed1 = PackedArrayDna::from(&dna1);
+            let packed2 = PackedArrayDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna2_ord(
+            dna1 in any::<[Nuc; 2]>(),
+            dna2 in any::<[Nuc; 2]>(),
+        ) {
+            let packed1 = PackedArrayDna::from(&dna1);
+            let packed2 = PackedArrayDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna3_ord(
+            dna1 in any::<[Nuc; 3]>(),
+            dna2 in any::<[Nuc; 3]>(),
+        ) {
+            let packed1 = PackedArrayDna::from(&dna1);
+            let packed2 = PackedArrayDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna4_ord(
+            dna1 in any::<[Nuc; 4]>(),
+            dna2 in any::<[Nuc; 4]>(),
+        ) {
+            let packed1 = PackedArrayDna::from(&dna1);
+            let packed2 = PackedArrayDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_dna5_ord(
+            dna1 in any::<[Nuc; 5]>(),
+            dna2 in any::<[Nuc; 5]>(),
+        ) {
+            let packed1 = PackedArrayDna::from(&dna1);
+            let packed2 = PackedArrayDna::from(&dna2);
+            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
+            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
         }
     }
 }

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -1,5 +1,6 @@
 //! Types related to packed ambiguous peptides.
 
+use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{Amino, Seq, iter::display};
@@ -117,6 +118,26 @@ impl IntoIterator for PackedPeptide {
 
     fn into_iter(self) -> Self::IntoIter {
         PackedPeptideIntoIter(UnpackingIter::new(0..self.len(), self.0))
+    }
+}
+
+impl PartialEq for PackedPeptide {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_flattened().eq(other.0.as_flattened())
+    }
+}
+
+impl Eq for PackedPeptide {}
+
+impl PartialOrd for PackedPeptide {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PackedPeptide {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_flattened().cmp(other.0.as_flattened())
     }
 }
 
@@ -263,6 +284,41 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayPeptideIntoIter(UnpackingIter::new(0..N, self.0))
+    }
+}
+
+impl<const N: usize> PartialEq for PackedArrayPeptide<N>
+where
+    [(); N]: PackableArray,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0
+            .as_ref()
+            .as_flattened()
+            .eq(other.0.as_ref().as_flattened())
+    }
+}
+
+impl<const N: usize> Eq for PackedArrayPeptide<N> where [(); N]: PackableArray {}
+
+impl<const N: usize> PartialOrd for PackedArrayPeptide<N>
+where
+    [(); N]: PackableArray,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for PackedArrayPeptide<N>
+where
+    [(); N]: PackableArray,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .as_ref()
+            .as_flattened()
+            .cmp(other.0.as_ref().as_flattened())
     }
 }
 
@@ -598,6 +654,66 @@ mod tests {
             let packed = PackedPeptide::from(&peptide);
             assert_eq!(packed.len(), peptide.len());
             assert_eq!(packed.is_empty(), peptide.is_empty());
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_peptide_ord(
+            peptide1 in any_peptide(0..50),
+            peptide2 in any_peptide(0..50),
+        ) {
+            let packed1 = PackedPeptide::from(&peptide1);
+            let packed2 = PackedPeptide::from(&peptide2);
+            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
+            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide1_ord(
+            peptide1 in any::<[Amino; 1]>(),
+            peptide2 in any::<[Amino; 1]>(),
+        ) {
+            let packed1 = PackedArrayPeptide::from(&peptide1);
+            let packed2 = PackedArrayPeptide::from(&peptide2);
+            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
+            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide2_ord(
+            peptide1 in any::<[Amino; 2]>(),
+            peptide2 in any::<[Amino; 2]>(),
+        ) {
+            let packed1 = PackedArrayPeptide::from(&peptide1);
+            let packed2 = PackedArrayPeptide::from(&peptide2);
+            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
+            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide3_ord(
+            peptide1 in any::<[Amino; 3]>(),
+            peptide2 in any::<[Amino; 3]>(),
+        ) {
+            let packed1 = PackedArrayPeptide::from(&peptide1);
+            let packed2 = PackedArrayPeptide::from(&peptide2);
+            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
+            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
+        }
+
+        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
+        #[test]
+        fn packed_array_peptide4_ord(
+            peptide1 in any::<[Amino; 4]>(),
+            peptide2 in any::<[Amino; 4]>(),
+        ) {
+            let packed1 = PackedArrayPeptide::from(&peptide1);
+            let packed2 = PackedArrayPeptide::from(&peptide2);
+            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
+            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
         }
     }
 }


### PR DESCRIPTION
This doesn't handle comparisons between packed and unpacked data.