### PR TITLE
Add `Default` and `Hash` impls for packed types.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 * `Seq` now has `complement` and `reverse_complement` methods. (#61)
 * `Seq` now supports `AsRef` and `AsMut`. (#67)
-* Add basic support for packed types! (#62, #66, #69, #70, #73, #74, #75)
+* Add basic support for packed types! (#62, #66, #69, #70, #73, #74, #75, #76)
 
 ## Version 0.4.0 (2026-07-28)
 

--- a/src/packed/ambidna.rs
+++ b/src/packed/ambidna.rs
@@ -1,6 +1,5 @@
 //! Types related to packed ambiguous DNA.
 
-use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{AmbiNuc, Seq, iter::display};
@@ -25,7 +24,7 @@ use super::{PackableArray, UnpackingIter};
 /// let unpacked: Vec<AmbiNuc> = packed.into();
 /// assert_eq!(unpacked, dna);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedAmbiDna(Vec<u8>);
 
 impl PackedAmbiDna {
@@ -118,26 +117,6 @@ impl IntoIterator for PackedAmbiDna {
     }
 }
 
-impl PartialEq for PackedAmbiDna {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl Eq for PackedAmbiDna {}
-
-impl PartialOrd for PackedAmbiDna {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PackedAmbiDna {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.cmp(&other.0)
-    }
-}
-
 impl std::fmt::Display for PackedAmbiDna {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         self.iter().fmt(f)
@@ -166,7 +145,7 @@ impl std::fmt::Debug for PackedAmbiDna {
 /// let unpacked: [AmbiNuc; 10] = packed.into();
 /// assert_eq!(unpacked, dna);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedArrayAmbiDna<const N: usize>(PackedBuf<N>)
 where
     [(); N]: PackableArray;
@@ -181,6 +160,15 @@ where
     #[must_use]
     pub fn iter(&self) -> PackedAmbiDnaIter<'_> {
         self.into_iter()
+    }
+}
+
+impl<const N: usize> Default for PackedArrayAmbiDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn default() -> Self {
+        Self(ArrayDefault::array_default())
     }
 }
 
@@ -281,35 +269,6 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayAmbiDnaIntoIter(UnpackingIter::new(0..N, self.0))
-    }
-}
-
-impl<const N: usize> PartialEq for PackedArrayAmbiDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_ref().eq(other.0.as_ref())
-    }
-}
-
-impl<const N: usize> Eq for PackedArrayAmbiDna<N> where [(); N]: PackableArray {}
-
-impl<const N: usize> PartialOrd for PackedArrayAmbiDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<const N: usize> Ord for PackedArrayAmbiDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -627,54 +586,6 @@ mod tests {
             let packed = PackedAmbiDna::from(&ambi_dna);
             assert_eq!(packed.len(), ambi_dna.len());
             assert_eq!(packed.is_empty(), ambi_dna.is_empty());
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_ambi_dna_ord(
-            ambi_dna1 in any_ambi_dna(0..50),
-            ambi_dna2 in any_ambi_dna(0..50),
-        ) {
-            let packed1 = PackedAmbiDna::from(&ambi_dna1);
-            let packed2 = PackedAmbiDna::from(&ambi_dna2);
-            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
-            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna1_ord(
-            ambi_dna1 in any::<[AmbiNuc; 1]>(),
-            ambi_dna2 in any::<[AmbiNuc; 1]>(),
-        ) {
-            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
-            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
-            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
-            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna2_ord(
-            ambi_dna1 in any::<[AmbiNuc; 2]>(),
-            ambi_dna2 in any::<[AmbiNuc; 2]>(),
-        ) {
-            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
-            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
-            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
-            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna3_ord(
-            ambi_dna1 in any::<[AmbiNuc; 3]>(),
-            ambi_dna2 in any::<[AmbiNuc; 3]>(),
-        ) {
-            let packed1 = PackedArrayAmbiDna::from(&ambi_dna1);
-            let packed2 = PackedArrayAmbiDna::from(&ambi_dna2);
-            assert_eq!(packed1.cmp(&packed2), ambi_dna1.cmp(&ambi_dna2));
-            assert_eq!(packed1.eq(&packed2), ambi_dna1.eq(&ambi_dna2));
         }
     }
 }

--- a/src/packed/ambipeptide.rs
+++ b/src/packed/ambipeptide.rs
@@ -1,9 +1,8 @@
 //! Types related to packed ambiguous peptides.
 
-use std::cmp::Ordering;
 use std::fmt::Formatter;
 
-use crate::{AmbiAmino, Seq, iter::display};
+use crate::{AmbiAmino, Seq, iter::display, packed::packable_array::ArrayDefault};
 
 // Note on storage: There's not much room for packing `AmbiAmino`s... we can shave off one byte,
 // but that's about it. Again, we store thing big-endian for lexical sorting reasons.
@@ -21,7 +20,7 @@ use crate::{AmbiAmino, Seq, iter::display};
 /// let unpacked: Vec<AmbiAmino> = packed.into();
 /// assert_eq!(unpacked, peptide);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedAmbiPeptide(Vec<[u8; 3]>);
 
 impl PackedAmbiPeptide {
@@ -106,26 +105,6 @@ impl IntoIterator for PackedAmbiPeptide {
     }
 }
 
-impl PartialEq for PackedAmbiPeptide {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_flattened().eq(other.0.as_flattened())
-    }
-}
-
-impl Eq for PackedAmbiPeptide {}
-
-impl PartialOrd for PackedAmbiPeptide {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PackedAmbiPeptide {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_flattened().cmp(other.0.as_flattened())
-    }
-}
-
 impl std::fmt::Display for PackedAmbiPeptide {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         self.iter().fmt(f)
@@ -154,7 +133,7 @@ impl std::fmt::Debug for PackedAmbiPeptide {
 /// let unpacked: [AmbiAmino; 18] = packed.into();
 /// assert_eq!(unpacked, peptide);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedArrayAmbiPeptide<const N: usize>([[u8; 3]; N]);
 
 impl<const N: usize> PackedArrayAmbiPeptide<N> {
@@ -162,6 +141,12 @@ impl<const N: usize> PackedArrayAmbiPeptide<N> {
     #[must_use]
     pub fn iter(&self) -> PackedAmbiPeptideIter<'_> {
         self.into_iter()
+    }
+}
+
+impl<const N: usize> Default for PackedArrayAmbiPeptide<N> {
+    fn default() -> Self {
+        Self(ArrayDefault::array_default())
     }
 }
 
@@ -210,26 +195,6 @@ impl<const N: usize> From<PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
 impl<const N: usize> From<&PackedArrayAmbiPeptide<N>> for [AmbiAmino; N] {
     fn from(packed_ambi_peptide: &PackedArrayAmbiPeptide<N>) -> [AmbiAmino; N] {
         packed_ambi_peptide.0.map(AmbiAmino::decompress)
-    }
-}
-
-impl<const N: usize> PartialEq for PackedArrayAmbiPeptide<N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_flattened().eq(other.0.as_flattened())
-    }
-}
-
-impl<const N: usize> Eq for PackedArrayAmbiPeptide<N> {}
-
-impl<const N: usize> PartialOrd for PackedArrayAmbiPeptide<N> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<const N: usize> Ord for PackedArrayAmbiPeptide<N> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_flattened().cmp(other.0.as_flattened())
     }
 }
 
@@ -407,7 +372,6 @@ impl std::fmt::Debug for PackedAmbiPeptideIter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use proptest::arbitrary::any;
     use proptest::proptest;
 
     use super::super::tests::{assert_both_roundtrips, assert_roundtrip};
@@ -475,43 +439,6 @@ mod tests {
             let packed = PackedAmbiPeptide::from(&ambi_peptide);
             assert_eq!(packed.len(), ambi_peptide.len());
             assert_eq!(packed.is_empty(), ambi_peptide.is_empty());
-        }
-
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_ambi_peptide_ord(
-            ambi_peptide1 in any_ambi_peptide(0..50),
-            ambi_peptide2 in any_ambi_peptide(0..50),
-        ) {
-            let packed1 = PackedAmbiPeptide::from(&ambi_peptide1);
-            let packed2 = PackedAmbiPeptide::from(&ambi_peptide2);
-            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
-            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_ambi_peptide1_ord(
-            ambi_peptide1 in any::<[AmbiAmino; 1]>(),
-            ambi_peptide2 in any::<[AmbiAmino; 1]>(),
-        ) {
-            let packed1 = PackedArrayAmbiPeptide::from(&ambi_peptide1);
-            let packed2 = PackedArrayAmbiPeptide::from(&ambi_peptide2);
-            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
-            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_peptide2_ord(
-            ambi_peptide1 in any::<[AmbiAmino; 2]>(),
-            ambi_peptide2 in any::<[AmbiAmino; 2]>(),
-        ) {
-            let packed1 = PackedArrayAmbiPeptide::from(&ambi_peptide1);
-            let packed2 = PackedArrayAmbiPeptide::from(&ambi_peptide2);
-            assert_eq!(packed1.cmp(&packed2), ambi_peptide1.cmp(&ambi_peptide2));
-            assert_eq!(packed1.eq(&packed2), ambi_peptide1.eq(&ambi_peptide2));
         }
     }
 }

--- a/src/packed/dna.rs
+++ b/src/packed/dna.rs
@@ -2,6 +2,7 @@
 
 use std::cmp::Ordering;
 use std::fmt::Formatter;
+use std::hash::{Hash, Hasher};
 
 use crate::{Nuc, Seq, iter::display};
 
@@ -31,7 +32,7 @@ use super::{PackableArray, UnpackingIter};
 /// let unpacked: Vec<Nuc> = packed.into();
 /// assert_eq!(unpacked, dna);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PackedDna(Vec<u8>);
 
 impl PackedDna {
@@ -131,6 +132,15 @@ impl IntoIterator for PackedDna {
     }
 }
 
+impl Hash for PackedDna {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match &*self.0 {
+            [] => [0u8].hash(state),
+            x => x.hash(state),
+        }
+    }
+}
+
 impl PartialEq for PackedDna {
     fn eq(&self, other: &Self) -> bool {
         match (&*self.0, &*other.0) {
@@ -199,7 +209,7 @@ impl std::fmt::Debug for PackedDna {
 /// let unpacked: [Nuc; 9] = packed.into();
 /// assert_eq!(unpacked, dna);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedArrayDna<const N: usize>(PackedBuf<N>)
 where
     [(); N]: PackableArray;
@@ -214,6 +224,15 @@ where
     #[must_use]
     pub fn iter(&self) -> PackedDnaIter<'_> {
         self.into_iter()
+    }
+}
+
+impl<const N: usize> Default for PackedArrayDna<N>
+where
+    [(); N]: PackableArray,
+{
+    fn default() -> Self {
+        Self(ArrayDefault::array_default())
     }
 }
 
@@ -314,35 +333,6 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayDnaIntoIter(UnpackingIter::new(0..N, self.0))
-    }
-}
-
-impl<const N: usize> PartialEq for PackedArrayDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_ref().eq(other.0.as_ref())
-    }
-}
-
-impl<const N: usize> Eq for PackedArrayDna<N> where [(); N]: PackableArray {}
-
-impl<const N: usize> PartialOrd for PackedArrayDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<const N: usize> Ord for PackedArrayDna<N>
-where
-    [(); N]: PackableArray,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -694,66 +684,6 @@ mod tests {
         ) {
             let packed1 = PackedDna::from(&dna1);
             let packed2 = PackedDna::from(&dna2);
-            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
-            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna1_ord(
-            dna1 in any::<[Nuc; 1]>(),
-            dna2 in any::<[Nuc; 1]>(),
-        ) {
-            let packed1 = PackedArrayDna::from(&dna1);
-            let packed2 = PackedArrayDna::from(&dna2);
-            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
-            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna2_ord(
-            dna1 in any::<[Nuc; 2]>(),
-            dna2 in any::<[Nuc; 2]>(),
-        ) {
-            let packed1 = PackedArrayDna::from(&dna1);
-            let packed2 = PackedArrayDna::from(&dna2);
-            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
-            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna3_ord(
-            dna1 in any::<[Nuc; 3]>(),
-            dna2 in any::<[Nuc; 3]>(),
-        ) {
-            let packed1 = PackedArrayDna::from(&dna1);
-            let packed2 = PackedArrayDna::from(&dna2);
-            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
-            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna4_ord(
-            dna1 in any::<[Nuc; 4]>(),
-            dna2 in any::<[Nuc; 4]>(),
-        ) {
-            let packed1 = PackedArrayDna::from(&dna1);
-            let packed2 = PackedArrayDna::from(&dna2);
-            assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
-            assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_dna5_ord(
-            dna1 in any::<[Nuc; 5]>(),
-            dna2 in any::<[Nuc; 5]>(),
-        ) {
-            let packed1 = PackedArrayDna::from(&dna1);
-            let packed2 = PackedArrayDna::from(&dna2);
             assert_eq!(packed1.cmp(&packed2), dna1.cmp(&dna2));
             assert_eq!(packed1.eq(&packed2), dna1.eq(&dna2));
         }

--- a/src/packed/mod.rs
+++ b/src/packed/mod.rs
@@ -1,5 +1,6 @@
 //! Packed sequence types
 
+use std::hash::Hash;
 use std::ops::Range;
 
 use crate::{AmbiAmino, AmbiNuc, Amino, Nuc, packed::packable_array::ContiguousIterator};
@@ -96,6 +97,8 @@ impl<const N: usize> Packable for [AmbiAmino; N] {
 pub trait PackableArray: packable_array::Sealed {}
 
 pub(crate) mod packable_array {
+    use std::hash::Hash;
+
     /// Implementation details of [`PackedArray`].
     ///
     /// This uses GATs rather than constants to work around limitations in the current
@@ -108,21 +111,30 @@ pub(crate) mod packable_array {
     /// trait constraints into everything else, complicating the public APIs.
     pub trait Sealed {
         /// `[T; N.div_ceil(2)]`
-        type By2<T: Copy + Default>: AsRef<[T]>
+        type By2<T: Copy + Default + Eq + Ord + Hash>: AsRef<[T]>
             + AsMut<[T]>
             + Copy
+            + Eq
+            + Ord
+            + Hash
             + ArrayDefault
             + IntoIterator<Item = T, IntoIter: ContiguousIterator<SliceItem = T>>;
         /// `[T; N.div_ceil(3)]`
-        type By3<T: Copy + Default>: AsRef<[T]>
+        type By3<T: Copy + Default + Eq + Ord + Hash>: AsRef<[T]>
             + AsMut<[T]>
             + Copy
+            + Eq
+            + Ord
+            + Hash
             + ArrayDefault
             + IntoIterator<Item = T, IntoIter: ContiguousIterator<SliceItem = T>>;
         /// `[T; N.div_ceil(4)]`
-        type By4<T: Copy + Default>: AsRef<[T]>
+        type By4<T: Copy + Default + Eq + Ord + Hash>: AsRef<[T]>
             + AsMut<[T]>
             + Copy
+            + Eq
+            + Ord
+            + Hash
             + ArrayDefault
             + IntoIterator<Item = T, IntoIter: ContiguousIterator<SliceItem = T>>;
     }
@@ -202,9 +214,9 @@ macro_rules! div_table {
             impl PackableArray for [(); $d] {}
 
             impl packable_array::Sealed for [(); $d] {
-                type By2<T: Copy + Default> = [T; $q2];
-                type By3<T: Copy + Default> = [T; $q3];
-                type By4<T: Copy + Default> = [T; $q4];
+                type By2<T: Copy + Default + Eq + Ord + Hash> = [T; $q2];
+                type By3<T: Copy + Default + Eq + Ord + Hash> = [T; $q3];
+                type By4<T: Copy + Default + Eq + Ord + Hash> = [T; $q4];
             }
         )+
     };

--- a/src/packed/peptide.rs
+++ b/src/packed/peptide.rs
@@ -1,6 +1,5 @@
 //! Types related to packed ambiguous peptides.
 
-use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::{Amino, Seq, iter::display};
@@ -26,7 +25,7 @@ use super::{PackableArray, UnpackingIter};
 /// let unpacked: Vec<Amino> = packed.into();
 /// assert_eq!(unpacked, peptide);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedPeptide(Vec<[u8; 2]>);
 
 impl PackedPeptide {
@@ -121,26 +120,6 @@ impl IntoIterator for PackedPeptide {
     }
 }
 
-impl PartialEq for PackedPeptide {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_flattened().eq(other.0.as_flattened())
-    }
-}
-
-impl Eq for PackedPeptide {}
-
-impl PartialOrd for PackedPeptide {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PackedPeptide {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_flattened().cmp(other.0.as_flattened())
-    }
-}
-
 impl std::fmt::Display for PackedPeptide {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         self.iter().fmt(f)
@@ -169,7 +148,7 @@ impl std::fmt::Debug for PackedPeptide {
 /// let unpacked: [Amino; 17] = packed.into();
 /// assert_eq!(unpacked, peptide);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PackedArrayPeptide<const N: usize>(PackedBuf<N>)
 where
     [(); N]: PackableArray;
@@ -184,6 +163,15 @@ where
     #[must_use]
     pub fn iter(&self) -> PackedPeptideIter<'_> {
         self.into_iter()
+    }
+}
+
+impl<const N: usize> Default for PackedArrayPeptide<N>
+where
+    [(); N]: PackableArray,
+{
+    fn default() -> Self {
+        Self(ArrayDefault::array_default())
     }
 }
 
@@ -284,41 +272,6 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         PackedArrayPeptideIntoIter(UnpackingIter::new(0..N, self.0))
-    }
-}
-
-impl<const N: usize> PartialEq for PackedArrayPeptide<N>
-where
-    [(); N]: PackableArray,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0
-            .as_ref()
-            .as_flattened()
-            .eq(other.0.as_ref().as_flattened())
-    }
-}
-
-impl<const N: usize> Eq for PackedArrayPeptide<N> where [(); N]: PackableArray {}
-
-impl<const N: usize> PartialOrd for PackedArrayPeptide<N>
-where
-    [(); N]: PackableArray,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<const N: usize> Ord for PackedArrayPeptide<N>
-where
-    [(); N]: PackableArray,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0
-            .as_ref()
-            .as_flattened()
-            .cmp(other.0.as_ref().as_flattened())
     }
 }
 
@@ -654,66 +607,6 @@ mod tests {
             let packed = PackedPeptide::from(&peptide);
             assert_eq!(packed.len(), peptide.len());
             assert_eq!(packed.is_empty(), peptide.is_empty());
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_peptide_ord(
-            peptide1 in any_peptide(0..50),
-            peptide2 in any_peptide(0..50),
-        ) {
-            let packed1 = PackedPeptide::from(&peptide1);
-            let packed2 = PackedPeptide::from(&peptide2);
-            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
-            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_peptide1_ord(
-            peptide1 in any::<[Amino; 1]>(),
-            peptide2 in any::<[Amino; 1]>(),
-        ) {
-            let packed1 = PackedArrayPeptide::from(&peptide1);
-            let packed2 = PackedArrayPeptide::from(&peptide2);
-            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
-            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_peptide2_ord(
-            peptide1 in any::<[Amino; 2]>(),
-            peptide2 in any::<[Amino; 2]>(),
-        ) {
-            let packed1 = PackedArrayPeptide::from(&peptide1);
-            let packed2 = PackedArrayPeptide::from(&peptide2);
-            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
-            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_peptide3_ord(
-            peptide1 in any::<[Amino; 3]>(),
-            peptide2 in any::<[Amino; 3]>(),
-        ) {
-            let packed1 = PackedArrayPeptide::from(&peptide1);
-            let packed2 = PackedArrayPeptide::from(&peptide2);
-            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
-            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
-        }
-
-        #[cfg_attr(miri, ignore = "slow in miri; shouldn't touch unsafe code anyway")]
-        #[test]
-        fn packed_array_peptide4_ord(
-            peptide1 in any::<[Amino; 4]>(),
-            peptide2 in any::<[Amino; 4]>(),
-        ) {
-            let packed1 = PackedArrayPeptide::from(&peptide1);
-            let packed2 = PackedArrayPeptide::from(&peptide2);
-            assert_eq!(packed1.cmp(&packed2), peptide1.cmp(&peptide2));
-            assert_eq!(packed1.eq(&packed2), peptide1.eq(&peptide2));
         }
     }
 }


### PR DESCRIPTION
Also remove brainfart of manual `{Partial,}{Eq,Ord}` implementations, along with their tests. (the exception is `PackedDna`, which needs its comparison impls due to the funky trailing-length format)